### PR TITLE
fix: prevent XSS in studio history rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "node --test",
     "build:studio": "npm run build -w studio",
     "build:workflow": "npm run build -w workflow-builder",
     "build:agent": "npm run build -w ai-agent",

--- a/src/components/CinemaStudio.js
+++ b/src/components/CinemaStudio.js
@@ -4,6 +4,7 @@ import { CameraControls } from './CameraControls.js';
 import { buildNanoBananaPrompt, CAMERA_MAP, LENS_MAP, FOCAL_PERSPECTIVE, APERTURE_EFFECT } from '../lib/promptUtils.js';
 import { AuthModal } from './AuthModal.js';
 import { t } from '../lib/i18n.js';
+import { createHistoryImageWithLabel } from '../lib/historyDom.mjs';
 
 export function CinemaStudio() {
     const container = document.createElement('div');
@@ -420,12 +421,16 @@ export function CinemaStudio() {
             const thumb = document.createElement('div');
             thumb.className = `relative group/thumb cursor-pointer rounded-lg overflow-hidden border-2 transition-all duration-300 aspect-square ${idx === 0 ? 'border-[#22d3ee] shadow-glow-sm' : 'border-white/10 hover:border-white/30'}`;
 
-            thumb.innerHTML = `
-                <img src="${entry.url}" class="w-full h-full object-cover opacity-80 group-hover/thumb:opacity-100 transition-opacity">
-                <div class="absolute inset-0 bg-black/50 opacity-0 group-hover/thumb:opacity-100 transition-opacity flex items-center justify-center">
-                    <span class="text-[8px] font-bold text-white uppercase">${t('cinema.load')}</span>
-                </div>
-            `;
+            const { media, overlay } = createHistoryImageWithLabel({
+                document,
+                url: entry.url,
+                mediaClassName: 'w-full h-full object-cover opacity-80 group-hover/thumb:opacity-100 transition-opacity',
+                overlayClassName: 'absolute inset-0 bg-black/50 opacity-0 group-hover/thumb:opacity-100 transition-opacity flex items-center justify-center',
+                labelClassName: 'text-[8px] font-bold text-white uppercase',
+                label: t('cinema.load'),
+            });
+            thumb.appendChild(media);
+            thumb.appendChild(overlay);
 
             thumb.onclick = () => loadHistoryItem(entry, thumb);
             historyList.appendChild(thumb);

--- a/src/components/ImageStudio.js
+++ b/src/components/ImageStudio.js
@@ -13,6 +13,7 @@ import { createUploadPicker } from './UploadPicker.js';
 import { savePendingJob, removePendingJob, getPendingJobs } from '../lib/pendingJobs.js';
 import { downloadImage } from '../../packages/studio/src/utils/downloadImage.js';
 import { appendGenerationRefundNotice } from '../../packages/studio/src/utils/generationLifecycle.js';
+import { createHistoryMediaWithDownload } from '../lib/historyDom.mjs';
 
 function createInlineInstructions(type) {
     const el = document.createElement('div');
@@ -1020,15 +1021,19 @@ export function ImageStudio() {
         generationHistory.forEach((entry, idx) => {
             const thumb = document.createElement('div');
             thumb.className = `relative group/thumb cursor-pointer rounded-xl overflow-hidden border-2 transition-all duration-300 ${idx === 0 ? 'border-primary shadow-glow' : 'border-white/10 hover:border-white/30'}`;
+            const promptPreview = typeof entry.prompt === 'string' ? entry.prompt.substring(0, 30) : '';
 
-            thumb.innerHTML = `
-                <img src="${entry.url}" alt="${entry.prompt?.substring(0, 30) || 'Generated'}" class="w-full aspect-square object-cover">
-                <div class="absolute inset-0 bg-black/60 opacity-0 group-hover/thumb:opacity-100 transition-opacity flex items-center justify-center gap-1">
-                    <button class="hist-download p-1.5 bg-primary rounded-lg text-black hover:scale-110 transition-transform" title="Download">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
-                    </button>
-                </div>
-            `;
+            const { media, overlay } = createHistoryMediaWithDownload({
+                document,
+                tagName: 'img',
+                url: entry.url,
+                alt: promptPreview || 'Generated',
+                mediaClassName: 'w-full aspect-square object-cover',
+                overlayClassName: 'absolute inset-0 bg-black/60 opacity-0 group-hover/thumb:opacity-100 transition-opacity flex items-center justify-center gap-1',
+                buttonClassName: 'hist-download p-1.5 bg-primary rounded-lg text-black hover:scale-110 transition-transform',
+            });
+            thumb.appendChild(media);
+            thumb.appendChild(overlay);
 
             thumb.onclick = (e) => {
                 if (e.target.closest('.hist-download')) {

--- a/src/components/LipSyncStudio.js
+++ b/src/components/LipSyncStudio.js
@@ -4,6 +4,7 @@ import { AuthModal } from './AuthModal.js';
 import { t } from '../lib/i18n.js';
 import { createUploadPicker } from './UploadPicker.js';
 import { savePendingJob, removePendingJob, getPendingJobs } from '../lib/pendingJobs.js';
+import { createHistoryMediaWithDownload } from '../lib/historyDom.mjs';
 
 export function LipSyncStudio() {
     const container = document.createElement('div');
@@ -541,14 +542,16 @@ export function LipSyncStudio() {
         generationHistory.forEach((entry, idx) => {
             const thumb = document.createElement('div');
             thumb.className = `relative group/thumb cursor-pointer rounded-xl overflow-hidden border-2 transition-all duration-300 ${idx === 0 ? 'border-primary shadow-glow' : 'border-white/10 hover:border-white/30'}`;
-            thumb.innerHTML = `
-                <video src="${entry.url}" preload="metadata" muted class="w-full aspect-square object-cover"></video>
-                <div class="absolute inset-0 bg-black/60 opacity-0 group-hover/thumb:opacity-100 transition-opacity flex items-center justify-center">
-                    <button class="hist-download p-1.5 bg-primary rounded-lg text-black hover:scale-110 transition-transform" title="Download">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
-                    </button>
-                </div>
-            `;
+            const { media, overlay } = createHistoryMediaWithDownload({
+                document,
+                tagName: 'video',
+                url: entry.url,
+                mediaClassName: 'w-full aspect-square object-cover',
+                overlayClassName: 'absolute inset-0 bg-black/60 opacity-0 group-hover/thumb:opacity-100 transition-opacity flex items-center justify-center',
+                buttonClassName: 'hist-download p-1.5 bg-primary rounded-lg text-black hover:scale-110 transition-transform',
+            });
+            thumb.appendChild(media);
+            thumb.appendChild(overlay);
             thumb.onclick = (e) => {
                 if (e.target.closest('.hist-download')) { downloadFile(entry.url, `lipsync-${entry.id || idx}.mp4`); return; }
                 showVideoInCanvas(entry.url);

--- a/src/components/VideoStudio.js
+++ b/src/components/VideoStudio.js
@@ -6,6 +6,7 @@ import { createUploadPicker } from './UploadPicker.js';
 import { savePendingJob, removePendingJob, getPendingJobs } from '../lib/pendingJobs.js';
 import { localAI, isLocalAIAvailable } from '../lib/localInferenceClient.js';
 import { isWan2gpModelId, getLocalModelById, localT2VModels, localI2VModels } from '../lib/localModels.js';
+import { createHistoryMediaWithDownload } from '../lib/historyDom.mjs';
 
 // Promotes a wan2gp catalog entry (lib/localModels.js shape) into the
 // `inputs`-shaped descriptor the Video Studio dropdowns/controls expect.
@@ -926,14 +927,16 @@ export function VideoStudio() {
             const thumb = document.createElement('div');
             thumb.className = `relative group/thumb cursor-pointer rounded-xl overflow-hidden border-2 transition-all duration-300 ${idx === 0 ? 'border-primary shadow-glow' : 'border-white/10 hover:border-white/30'}`;
 
-            thumb.innerHTML = `
-                <video src="${entry.url}" preload="metadata" muted class="w-full aspect-square object-cover"></video>
-                <div class="absolute inset-0 bg-black/60 opacity-0 group-hover/thumb:opacity-100 transition-opacity flex items-center justify-center gap-1">
-                    <button class="hist-download p-1.5 bg-primary rounded-lg text-black hover:scale-110 transition-transform" title="Download">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
-                    </button>
-                </div>
-            `;
+            const { media, overlay } = createHistoryMediaWithDownload({
+                document,
+                tagName: 'video',
+                url: entry.url,
+                mediaClassName: 'w-full aspect-square object-cover',
+                overlayClassName: 'absolute inset-0 bg-black/60 opacity-0 group-hover/thumb:opacity-100 transition-opacity flex items-center justify-center gap-1',
+                buttonClassName: 'hist-download p-1.5 bg-primary rounded-lg text-black hover:scale-110 transition-transform',
+            });
+            thumb.appendChild(media);
+            thumb.appendChild(overlay);
 
             thumb.onclick = (e) => {
                 if (e.target.closest('.hist-download')) {

--- a/src/lib/historyDom.mjs
+++ b/src/lib/historyDom.mjs
@@ -1,0 +1,88 @@
+const DOWNLOAD_ICON = `
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+`;
+
+function getDocument(documentRef) {
+    if (!documentRef || typeof documentRef.createElement !== 'function') {
+        throw new TypeError('A document with createElement is required');
+    }
+    return documentRef;
+}
+
+function createMediaElement({ document: documentRef, tagName, url, alt, className }) {
+    const doc = getDocument(documentRef);
+    if (tagName !== 'img' && tagName !== 'video') {
+        throw new TypeError(`Unsupported history media element: ${tagName}`);
+    }
+
+    const media = doc.createElement(tagName);
+    media.src = typeof url === 'string' ? url : '';
+    media.className = className || '';
+
+    if (tagName === 'img') {
+        media.alt = typeof alt === 'string' ? alt : '';
+    } else {
+        media.preload = 'metadata';
+        media.muted = true;
+    }
+
+    return media;
+}
+
+export function createHistoryMediaWithDownload({
+    document: documentRef = globalThis.document,
+    tagName,
+    url,
+    alt = '',
+    mediaClassName,
+    overlayClassName,
+    buttonClassName,
+    buttonTitle = 'Download',
+}) {
+    const doc = getDocument(documentRef);
+    const media = createMediaElement({
+        document: doc,
+        tagName,
+        url,
+        alt,
+        className: mediaClassName,
+    });
+    const overlay = doc.createElement('div');
+    overlay.className = overlayClassName || '';
+
+    const downloadButton = doc.createElement('button');
+    downloadButton.className = buttonClassName || '';
+    downloadButton.title = typeof buttonTitle === 'string' ? buttonTitle : '';
+    downloadButton.innerHTML = DOWNLOAD_ICON;
+
+    overlay.appendChild(downloadButton);
+    return { media, overlay, downloadButton };
+}
+
+export function createHistoryImageWithLabel({
+    document: documentRef = globalThis.document,
+    url,
+    alt = '',
+    mediaClassName,
+    overlayClassName,
+    labelClassName,
+    label,
+}) {
+    const doc = getDocument(documentRef);
+    const media = createMediaElement({
+        document: doc,
+        tagName: 'img',
+        url,
+        alt,
+        className: mediaClassName,
+    });
+    const overlay = doc.createElement('div');
+    overlay.className = overlayClassName || '';
+
+    const labelElement = doc.createElement('span');
+    labelElement.className = labelClassName || '';
+    labelElement.textContent = typeof label === 'string' ? label : '';
+
+    overlay.appendChild(labelElement);
+    return { media, overlay, labelElement };
+}

--- a/tests/historyDom.test.js
+++ b/tests/historyDom.test.js
@@ -1,0 +1,98 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function createFakeDocument() {
+    const innerHtmlWrites = [];
+
+    class FakeElement {
+        constructor(tagName) {
+            this.tagName = tagName.toUpperCase();
+            this.children = [];
+            this.className = '';
+            this.textContent = '';
+        }
+
+        appendChild(child) {
+            this.children.push(child);
+            return child;
+        }
+
+        set innerHTML(value) {
+            const stringValue = String(value);
+            innerHtmlWrites.push({ tagName: this.tagName, value: stringValue });
+            this._innerHTML = stringValue;
+        }
+
+        get innerHTML() {
+            return this._innerHTML || '';
+        }
+    }
+
+    return {
+        document: {
+            createElement: (tagName) => new FakeElement(tagName),
+        },
+        innerHtmlWrites,
+    };
+}
+
+test('history download media keeps untrusted URL and prompt out of HTML setters', async () => {
+    const { createHistoryMediaWithDownload } = await import('../src/lib/historyDom.mjs');
+    const { document, innerHtmlWrites } = createFakeDocument();
+    const maliciousUrl = 'https://example.invalid/x" onerror="globalThis.pwned=true';
+    const maliciousPrompt = 'preview" onerror="globalThis.pwned=true';
+
+    const { media, overlay, downloadButton } = createHistoryMediaWithDownload({
+        document,
+        tagName: 'img',
+        url: maliciousUrl,
+        alt: maliciousPrompt,
+        mediaClassName: 'history-image',
+        overlayClassName: 'history-overlay',
+        buttonClassName: 'hist-download',
+        buttonTitle: maliciousPrompt,
+    });
+
+    assert.equal(media.src, maliciousUrl);
+    assert.equal(media.alt, maliciousPrompt);
+    assert.equal(downloadButton.title, maliciousPrompt);
+    assert.deepEqual(overlay.children, [downloadButton]);
+    assert.equal(innerHtmlWrites.length, 1, 'only the static download SVG uses innerHTML');
+    assert.match(innerHtmlWrites[0].value, /^\s*<svg\b/);
+    assert.doesNotMatch(innerHtmlWrites[0].value, /onerror|globalThis\.pwned/);
+});
+
+test('history video URL is assigned as a property and preserves media settings', async () => {
+    const { createHistoryMediaWithDownload } = await import('../src/lib/historyDom.mjs');
+    const { document, innerHtmlWrites } = createFakeDocument();
+    const maliciousUrl = 'https://example.invalid/video.mp4" onerror="globalThis.pwned=true';
+
+    const { media } = createHistoryMediaWithDownload({
+        document,
+        tagName: 'video',
+        url: maliciousUrl,
+    });
+
+    assert.equal(media.src, maliciousUrl);
+    assert.equal(media.preload, 'metadata');
+    assert.equal(media.muted, true);
+    assert.equal(innerHtmlWrites.some(({ value }) => value.includes(maliciousUrl)), false);
+});
+
+test('history label uses textContent for localized copy', async () => {
+    const { createHistoryImageWithLabel } = await import('../src/lib/historyDom.mjs');
+    const { document, innerHtmlWrites } = createFakeDocument();
+    const maliciousUrl = 'https://example.invalid/x" onerror="globalThis.pwned=true';
+    const maliciousLabel = 'Load <img src=x onerror="globalThis.pwned=true">';
+
+    const { media, overlay, labelElement } = createHistoryImageWithLabel({
+        document,
+        url: maliciousUrl,
+        label: maliciousLabel,
+    });
+
+    assert.equal(media.src, maliciousUrl);
+    assert.equal(labelElement.textContent, maliciousLabel);
+    assert.deepEqual(overlay.children, [labelElement]);
+    assert.deepEqual(innerHtmlWrites, []);
+});


### PR DESCRIPTION
## Summary

- render image, video, cinema, and lip-sync history media through DOM properties instead of interpolating persisted values into innerHTML
- keep localized labels in textContent and centralize safe history node construction
- add regression coverage for hostile URL, prompt, title, and label values, plus expose the Node test suite through npm test

## Security impact

History entries restored from localStorage can no longer break out of src, alt, or title attributes and inject event handlers during page load.

## Testing

- npm test (20 tests)
- npm run vite:build
- npm run build:packages
- npm run build
- Chromium DOM check with malicious values: no onerror attributes were created and the payload did not execute

Fixes #309