### PR TITLE
fix: avoid replaying buffered generation stages

### DIFF
--- a/electron/lib/localInferenceRuntime.js
+++ b/electron/lib/localInferenceRuntime.js
@@ -42,7 +42,7 @@ function stripAnsiSequences(text) {
     return text.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '');
 }
 
-function extractProgressEvents(text) {
+function extractProgressEvents(text, consumedLength = 0) {
     const events = [];
     const patterns = [
         /step\s+(\d+)\s*\/\s*(\d+)/ig,
@@ -54,7 +54,7 @@ function extractProgressEvents(text) {
         while (match) {
             const step = Number.parseInt(match[1], 10);
             const totalSteps = Number.parseInt(match[2], 10);
-            if (Number.isFinite(step) && Number.isFinite(totalSteps) && totalSteps > 0) {
+            if (pattern.lastIndex > consumedLength && Number.isFinite(step) && Number.isFinite(totalSteps) && totalSteps > 0) {
                 events.push({
                     step,
                     totalSteps,
@@ -75,7 +75,7 @@ function extractProgressEvents(text) {
 function parseGenerationProgressChunk(chunk, state = { tail: '', lastStep: 0, lastTotalSteps: 0 }) {
     const normalizedChunk = stripAnsiSequences(String(chunk)).replace(/\r/g, '\n');
     const combined = `${state.tail}${normalizedChunk}`;
-    const events = extractProgressEvents(combined);
+    const events = extractProgressEvents(combined, state.tail.length);
     const freshEvents = [];
 
     for (const event of events) {

--- a/tests/localInferenceProgress.test.js
+++ b/tests/localInferenceProgress.test.js
@@ -63,3 +63,24 @@ test('parseGenerationProgressChunk does not replay old buffered steps when later
         { step: 3, totalSteps: 3, progress: 1 },
     ]);
 });
+
+test('parseGenerationProgressChunk does not replay a previous stage on unrelated output', () => {
+    const state = { tail: '', lastStep: 0, lastTotalSteps: 0 };
+    parseGenerationProgressChunk('step 2/2\n', state);
+    assert.deepEqual(parseGenerationProgressChunk('step 1/3\n', state), [
+        { step: 1, totalSteps: 3, progress: 1 / 3 },
+    ]);
+
+    assert.deepEqual(parseGenerationProgressChunk('writing preview\n', state), []);
+    assert.deepEqual(parseGenerationProgressChunk('step 2/3\n', state), [
+        { step: 2, totalSteps: 3, progress: 2 / 3 },
+    ]);
+});
+
+test('parseGenerationProgressChunk still joins a progress record split across chunks', () => {
+    const state = { tail: '', lastStep: 0, lastTotalSteps: 0 };
+    assert.deepEqual(parseGenerationProgressChunk('step 1/', state), []);
+    assert.deepEqual(parseGenerationProgressChunk('20\n', state), [
+        { step: 1, totalSteps: 20, progress: 0.05 },
+    ]);
+});


### PR DESCRIPTION
After progress changes from `step 2/2` to `step 1/3`, an unrelated output chunk reprocesses both buffered stages and emits their progress again. This can make the UI jump between completed and active stages while no new step has finished.

Only extract progress matches that extend into the newly received chunk. Retain the old tail so records split across chunks still parse correctly.

Validation: `node --test tests/*.test.js` passes all 19 tests. The new stage-transition regression fails before the fix, and a second case verifies a record split between `step 1/` and `20` still emits progress. No model download or inference run is needed for these parser tests.
