### PR TITLE
feat(studio): simplify Seedance model selection

### DIFF
--- a/packages/studio/src/components/ModelParameterControls.jsx
+++ b/packages/studio/src/components/ModelParameterControls.jsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Children, useRef } from "react";
+
 import {
   PROMPT_CONTROL_LABEL_CLASS,
   PromptChevronIcon,
@@ -182,49 +184,93 @@ export default function ModelParameterControls({
   onChange,
   open,
   onToggle,
+  children,
+  label = <span className="text-[10px] font-black text-primary/80">PARAMS</span>,
+  title = "Model parameters",
+  summary = inputs.length,
+  fitViewport = false,
+  solid = false,
+  advancedKeys = [],
+  advancedLabel = "Advanced",
+  advancedChildren,
 }) {
-  if (inputs.length === 0) return null;
+  const triggerRef = useRef(null);
+  const extraControls = Children.toArray(children);
+  const extraAdvancedControls = Children.toArray(advancedChildren);
+  if (inputs.length === 0 && extraControls.length === 0 && extraAdvancedControls.length === 0) return null;
+  const advancedKeySet = new Set(advancedKeys);
+  const primaryInputs = [];
+  const advancedInputs = [];
+  for (const input of inputs) {
+    (advancedKeySet.has(input.key) ? advancedInputs : primaryInputs).push(input);
+  }
+  const renderInput = ({ key, schema }) => (
+    <div key={key} className="flex flex-col gap-2">
+      <div className={schema.type === "boolean" ? "flex items-center justify-between gap-4" : "flex flex-col gap-2"}>
+        <FieldLabel schema={schema} inputKey={key} />
+        {schema.type === "array" ? (
+          <ArrayInput
+            schema={schema}
+            label={schema.title || key.replaceAll("_", " ")}
+            value={values[key]}
+            onChange={(nextValue) => onChange(key, nextValue)}
+          />
+        ) : (
+          <ScalarInput
+            schema={schema}
+            label={schema.title || key.replaceAll("_", " ")}
+            value={values[key]}
+            onChange={(nextValue) => onChange(key, nextValue)}
+          />
+        )}
+      </div>
+    </div>
+  );
 
   return (
-    <div className="relative">
+    <div
+      className="relative"
+      onKeyDown={(event) => {
+        if (!open || event.key !== "Escape") return;
+        event.preventDefault();
+        event.stopPropagation();
+        onToggle(event);
+        triggerRef.current?.focus();
+      }}
+    >
       <button
         type="button"
+        ref={triggerRef}
+        aria-expanded={open}
         onClick={onToggle}
         className={promptControlClassName({ active: open })}
       >
-        <span className="text-[10px] font-black text-primary/80">PARAMS</span>
-        <span className={PROMPT_CONTROL_LABEL_CLASS}>{inputs.length}</span>
+        <span className={PROMPT_CONTROL_LABEL_CLASS}>{label}</span>
+        {summary !== "" && <span className={PROMPT_CONTROL_LABEL_CLASS}>{summary}</span>}
         <PromptChevronIcon />
       </button>
       {open && (
         <PromptPopover
+          fitViewport={fitViewport}
+          solid={solid}
           onClick={(event) => event.stopPropagation()}
           className="w-[min(420px,calc(100vw-2rem))] max-h-[60vh]"
         >
-          <PromptPopoverHeader>Model parameters</PromptPopoverHeader>
+          <PromptPopoverHeader>{title}</PromptPopoverHeader>
           <div className="flex flex-col gap-4">
-            {inputs.map(({ key, schema }) => (
-              <div key={key} className="flex flex-col gap-2">
-                <div className={schema.type === "boolean" ? "flex items-center justify-between gap-4" : "flex flex-col gap-2"}>
-                  <FieldLabel schema={schema} inputKey={key} />
-                  {schema.type === "array" ? (
-                    <ArrayInput
-                      schema={schema}
-                      label={schema.title || key.replaceAll("_", " ")}
-                      value={values[key]}
-                      onChange={(nextValue) => onChange(key, nextValue)}
-                    />
-                  ) : (
-                    <ScalarInput
-                      schema={schema}
-                      label={schema.title || key.replaceAll("_", " ")}
-                      value={values[key]}
-                      onChange={(nextValue) => onChange(key, nextValue)}
-                    />
-                  )}
+            {extraControls}
+            {primaryInputs.map(renderInput)}
+            {(advancedInputs.length > 0 || extraAdvancedControls.length > 0) && (
+              <details className="border-t border-white/[0.07] pt-2">
+                <summary className="cursor-pointer py-2 text-xs font-semibold text-white/60 focus-visible:outline focus-visible:outline-1 focus-visible:outline-primary">
+                  {advancedLabel}
+                </summary>
+                <div className="flex flex-col gap-4 pt-2">
+                  {advancedInputs.map(renderInput)}
+                  {extraAdvancedControls}
                 </div>
-              </div>
-            ))}
+              </details>
+            )}
           </div>
         </PromptPopover>
       )}

--- a/packages/studio/src/components/SeedanceControls.jsx
+++ b/packages/studio/src/components/SeedanceControls.jsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useId } from "react";
+
+import usePromptMenu from "./prompt/usePromptMenu.js";
+import ModelParameterControls from "./ModelParameterControls.jsx";
+import {
+  PROMPT_CONTROL_LABEL_CLASS,
+  PromptChevronIcon,
+  PromptMenuItem,
+  PromptPopover,
+  PromptPopoverHeader,
+  promptControlClassName,
+} from "./prompt/PromptComposer.jsx";
+
+const SELECT_CLASS = "w-full rounded-lg border border-white/10 bg-[#17191c] px-3 py-2 text-xs text-white outline-none focus:border-[#22d3ee]/50";
+const ADVANCED_KEYS = ["seed"];
+
+export function SeedanceOptionControl({ label, field, icon, open, onToggle, onSelect, copy }) {
+  const controlId = useId();
+  const menuId = `${controlId}-menu`;
+  const { triggerRef, menuRef, onTriggerKeyDown, onMenuKeyDown, restoreFocus } = usePromptMenu({
+    open, onOpen: onToggle, onClose: onToggle, selectionKey: field?.value,
+  });
+  if (!field) return null;
+  const selected = field.options.find((option) => option.value === field.value);
+  const optionLabel = (option) => field.key === "speed"
+    ? copy.speeds[option.value] || option.label
+    : option.label;
+  const selectedLabel = selected ? optionLabel(selected) : field.label || label;
+  if (field.options.length === 0 || (field.options.length === 1 && selected)) {
+    if (field.key !== "resolution" || (field.options.length === 0 && !field.label)) return null;
+    return (
+      <div
+        role="group"
+        aria-label={`${label}: ${selectedLabel}`}
+        className={promptControlClassName({ className: "pointer-events-none" })}
+      >
+        {icon}
+        <span className="text-xs font-semibold">{selectedLabel}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        ref={triggerRef}
+        id={controlId}
+        aria-controls={menuId}
+        aria-label={`${label}: ${selectedLabel}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={onToggle}
+        onKeyDown={onTriggerKeyDown}
+        className={promptControlClassName({ active: open })}
+      >
+        {icon}
+        <span className={PROMPT_CONTROL_LABEL_CLASS}>{selectedLabel}</span>
+        <PromptChevronIcon />
+      </button>
+      {open && (
+        <PromptPopover
+          fitViewport
+          solid
+          className="w-[min(280px,calc(100vw-2rem))]"
+          style={{ maxHeight: "60vh" }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <PromptPopoverHeader>{label}</PromptPopoverHeader>
+          <div ref={menuRef} id={menuId} role="menu" aria-labelledby={controlId} onKeyDown={onMenuKeyDown} className="flex flex-col gap-1">
+            {field.options.map((option) => (
+              <PromptMenuItem
+                key={option.value}
+                selected={field.value === option.value}
+                disabled={option.disabled}
+                className="disabled:opacity-40 disabled:cursor-not-allowed"
+                wrapDescription
+                description={(option.description || option.adjustmentDescription || option.disabled) && (
+                  <span className="block">
+                    {option.description}
+                    {option.adjustmentDescription && (
+                      <span className="block text-[#22d3ee]/75">{option.adjustmentDescription}</span>
+                    )}
+                    {option.disabled && <span className="block">{copy.incompatibleShort}</span>}
+                  </span>
+                )}
+                onClick={() => {
+                  onSelect(option);
+                  restoreFocus();
+                }}
+              >
+                {optionLabel(option)}
+              </PromptMenuItem>
+            ))}
+          </div>
+        </PromptPopover>
+      )}
+    </div>
+  );
+}
+
+export function SeedanceSettingsControl({
+  profile, qualities, quality, onProfileChange, onQualityChange, onDefaultResolution,
+  inputs, values, onChange, open, onToggle, copy,
+}) {
+  const profileGroupId = useId();
+  const profileCopy = (option) => copy.profiles[option.value] || option;
+  const renderProfile = (option) => {
+    const text = profileCopy(option);
+    const descriptionId = `${profileGroupId}-${option.value}-description`;
+    const hasDescription = text.description || option.adjustmentDescription || option.disabled;
+    return (
+      <label
+        key={option.value}
+        className={`flex items-start gap-3 rounded-lg px-3 py-2 text-xs transition-colors focus-within:ring-1 focus-within:ring-[#22d3ee]/50 ${
+          option.disabled ? "cursor-not-allowed opacity-40" : "cursor-pointer hover:bg-white/[0.04]"
+        } ${profile.value === option.value ? "bg-[#22d3ee]/[0.07]" : ""}`}
+      >
+        <input
+          type="radio"
+          name={profileGroupId}
+          value={option.value}
+          checked={profile.value === option.value}
+          disabled={option.disabled}
+          aria-label={text.label}
+          aria-describedby={hasDescription ? descriptionId : undefined}
+          onChange={() => onProfileChange(option.value)}
+          className="mt-0.5 h-3.5 w-3.5 shrink-0 accent-[#22d3ee]"
+        />
+        <span className="min-w-0">
+          <span className="flex flex-wrap items-center gap-x-2 gap-y-1 font-semibold text-white/80">
+            {text.label}
+            {option.value === "standard" && (
+              <span className="text-[10px] font-medium text-white/45">{copy.defaultVariant}</span>
+            )}
+          </span>
+          {hasDescription && (
+            <span id={descriptionId} className="mt-1 block text-[11px] leading-relaxed text-white/45">
+              {text.description}
+              {option.adjustmentDescription && (
+                <span className="block text-[#22d3ee]/75">{option.adjustmentDescription}</span>
+              )}
+              {option.disabled && <span className="block">{copy.incompatibleShort}</span>}
+            </span>
+          )}
+        </span>
+      </label>
+    );
+  };
+  return (
+    <ModelParameterControls
+      inputs={inputs}
+      values={values}
+      onChange={onChange}
+      open={open}
+      onToggle={onToggle}
+      label={copy.settings}
+      title={copy.settings}
+      summary=""
+      fitViewport
+      solid
+      advancedKeys={ADVANCED_KEYS}
+      advancedLabel={copy.advanced}
+      advancedChildren={profile?.options.length > 1 && (
+        <fieldset className="min-w-0">
+          <legend className="text-xs font-semibold text-white/75">{copy.provider}</legend>
+          <p className="mb-2 mt-1 text-[11px] leading-relaxed text-white/45">{copy.providerHelp}</p>
+          {profile.options.map(renderProfile)}
+          {onDefaultResolution && (
+            <button type="button" onClick={onDefaultResolution}
+              className="mt-2 px-3 py-2 text-xs text-[#22d3ee] hover:underline focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#22d3ee]">
+              {copy.restoreDefaultResolution}
+            </button>
+          )}
+        </fieldset>
+      )}
+    >
+      {qualities.length > 0 && (
+        <label className="flex flex-col gap-2 text-xs text-white/75">
+          <span className="font-semibold">{copy.quality}</span>
+          <select aria-label={copy.quality} className={SELECT_CLASS} value={quality} onChange={(event) => onQualityChange(event.target.value)}>
+            {qualities.map((value) => <option key={value} value={value}>{value}</option>)}
+          </select>
+        </label>
+      )}
+    </ModelParameterControls>
+  );
+}

--- a/packages/studio/src/components/VideoStudio.jsx
+++ b/packages/studio/src/components/VideoStudio.jsx
@@ -7,6 +7,7 @@ import { formatErrorMessage } from "../utils/formatError.js";
 import { scopedPersistKey, migrateLegacyPersistKey } from "../persistKey.js";
 import DrawModal from "./DrawModal.jsx";
 import ModelParameterControls from "./ModelParameterControls.jsx";
+import { SeedanceOptionControl, SeedanceSettingsControl } from "./SeedanceControls.jsx";
 import MobileGenerationActions, {
   GenerationCopyButtons,
 } from "./MobileGenerationActions.jsx";
@@ -24,9 +25,25 @@ import {
 import {
   getFamilyVariant,
   videoModelCatalog,
-  videoModelPickerEntries,
-  videoModelPickerEntryByVariantId,
+  videoModelMenuEntries as videoModelPickerEntries,
+  videoModelMenuEntryByVariantId as videoModelPickerEntryByVariantId,
 } from "../modelFamilies.js";
+import {
+  getSeedanceConfiguration,
+  getSeedanceEndpointResolution,
+  getSeedanceVariantOptions,
+  getSeedanceToolConfiguration,
+} from "../seedanceModels.js";
+import {
+  getSeedanceCommonOptions,
+  getSeedanceCommonValues,
+  getSeedanceResolutionOptions,
+  planSeedanceSelection,
+  getSeedanceSelectionAdjustments,
+  buildSeedanceCommonPayload,
+  migrateSeedanceResolutionSelection,
+} from "../seedanceParameters.js";
+import { getSeedanceModeDescription } from "../seedanceCopy.js";
 import {
   buildReferenceParams,
   getModelMediaCapabilities,
@@ -38,6 +55,7 @@ import {
   createModelParameterValues,
   getSupplementalModelInputs,
 } from "../modelParameters.js";
+import { isContinuationSourceModel } from "../videoToolCapabilities.js";
 import {
   appendVideoWorkflowMedia,
   buildVideoWorkflowMediaParams,
@@ -76,6 +94,7 @@ import {
   promptControlClassName,
   promptMediaButtonClassName,
 } from "./prompt/PromptComposer.jsx";
+import usePromptMenu from "./prompt/usePromptMenu.js";
 import en from "../messages/en/videoStudio.json";
 import zh from "../messages/zh/videoStudio.json";
 import { resolveCopy } from "../i18nUtils";
@@ -413,6 +432,14 @@ const PROVIDER_LOGOS = {
 
 const invertLogos = ['openai', 'blackforest', 'runway', 'ideogram', 'lightricks', 'grok'];
 
+function seedanceToolLabel(tool, copy, includeAction = false) {
+  return [
+    includeAction ? copy.seedance.toolNames[tool.group] : null,
+    copy.seedance.toolVariants[tool.variant],
+    tool.resolution,
+  ].filter(Boolean).join(" · ");
+}
+
 function ModelDropdown({ selectedModel, onSelect, onClose, copy = en }) {
   const [search, setSearch] = useState("");
   const selectedEntry = videoModelPickerEntryByVariantId.get(selectedModel);
@@ -516,6 +543,14 @@ function ModelDropdown({ selectedModel, onSelect, onClose, copy = en }) {
     // 2. Filter by search query
     return entry.searchText.includes(lf);
   });
+  const selectedTool = getSeedanceToolConfiguration(selectedModel);
+  const mainEntries = [];
+  const seedanceToolsByGroup = { continueGenerated: [], removeWatermark: [] };
+  for (const entry of filtered) {
+    const tool = getSeedanceToolConfiguration(entry.defaultVariant.model.id);
+    if (tool) seedanceToolsByGroup[tool.group][tool.order] = entry;
+    else mainEntries.push(entry);
+  }
 
   const getIconColor = (family) => {
     if (family.id.includes("kling")) return "bg-blue-500/10 text-blue-400 border-blue-500/10";
@@ -524,14 +559,16 @@ function ModelDropdown({ selectedModel, onSelect, onClose, copy = en }) {
     return "bg-primary/10 text-primary border-primary/10";
   };
 
-  const renderItem = (entry) => {
+  const renderItem = (entry, label = entry.name) => {
     const { family } = entry;
     const isSelected = selectedEntry === entry;
     return (
-    <div
+    <button
+      type="button"
       key={entry.id}
+      aria-pressed={isSelected}
       ref={isSelected ? activeItemRef : null}
-      className={`flex items-center justify-between p-3.5 hover:bg-white/5 rounded-2xl cursor-pointer transition-all border border-transparent hover:border-white/5 ${isSelected ? "bg-white/5 border-white/5" : ""}`}
+      className={`flex w-full text-left items-center justify-between p-3.5 hover:bg-white/5 rounded-2xl cursor-pointer transition-all border border-transparent hover:border-white/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary ${isSelected ? "bg-white/5 border-white/5" : ""}`}
       onClick={(e) => {
         e.stopPropagation();
         onSelect(entry, activeCategory.id);
@@ -556,7 +593,7 @@ function ModelDropdown({ selectedModel, onSelect, onClose, copy = en }) {
         )}
         <div className="flex flex-col gap-0.5 min-w-0">
           <span className="text-xs font-bold text-white tracking-tight truncate">
-            {entry.name}
+            {label}
           </span>
           <div className="flex items-center gap-1.5">
             {selectedProvider === "all" && family.provider_name && (
@@ -568,7 +605,7 @@ function ModelDropdown({ selectedModel, onSelect, onClose, copy = en }) {
         </div>
       </div>
       {isSelected && <CheckSvg />}
-    </div>
+    </button>
     );
   };
 
@@ -686,7 +723,25 @@ function ModelDropdown({ selectedModel, onSelect, onClose, copy = en }) {
               No models found
             </div>
           ) : (
-            filtered.map((entry) => renderItem(entry))
+            <>
+              {mainEntries.map((entry) => renderItem(entry))}
+              {mainEntries.length < filtered.length && (
+                <details open={Boolean(search.trim()) || Boolean(selectedTool)} className="mt-2 border-t border-white/5 pt-2">
+                  <summary className="cursor-pointer px-3 py-2 text-xs font-semibold text-white/50">
+                    {copy.seedance.tools}
+                  </summary>
+                  {["continueGenerated", "removeWatermark"].map((group) => {
+                    const entries = seedanceToolsByGroup[group].filter(Boolean);
+                    return entries.length > 0 && (
+                      <div key={group} role="group" aria-label={copy.seedance[group]} className="pt-2">
+                        <p className="px-3 pb-1 text-[11px] font-semibold text-white/60">{copy.seedance[group]}</p>
+                        {entries.map((entry) => renderItem(entry, seedanceToolLabel(getSeedanceToolConfiguration(entry.defaultVariant.model.id), copy)))}
+                      </div>
+                    );
+                  })}
+                </details>
+              )}
+            </>
           )}
         </div>
       </div>
@@ -713,7 +768,7 @@ export default function VideoStudio({
   onFilesHandled,
   locale = "en",
 }) {
-  const copy = resolveCopy(en, zh, locale);
+  const copy = useMemo(() => resolveCopy(en, zh, locale), [locale]);
   const LEGACY_PERSIST_KEY = "hg_video_studio_persistent";
   const PERSIST_KEY = scopedPersistKey(LEGACY_PERSIST_KEY, apiKey);
   useEffect(() => {
@@ -771,6 +826,8 @@ export default function VideoStudio({
   const [audioProgress, setAudioProgress] = useState(0);
   const [workflowMediaDrafts, setWorkflowMediaDrafts] = useState({});
   const [workflowUploadSlotId, setWorkflowUploadSlotId] = useState(null);
+  const mediaUploading = imageUploading || endImageUploading || videoUploading ||
+    audioUploading || Boolean(workflowUploadSlotId);
   const uploadedImageUrl = uploadedImageUrls[0] || null;
   const uploadedVideoUrl = uploadedVideoUrls[0] || null;
 
@@ -803,9 +860,6 @@ export default function VideoStudio({
   const videoFileInputRef = useRef(null);
   const audioFileInputRef = useRef(null);
   const resultVideoRef = useRef(null);
-  const workflowTriggerRef = useRef(null);
-  const workflowMenuRef = useRef(null);
-  const workflowMenuFocusTargetRef = useRef("selected");
   const workflowControlId = useId();
   const workflowMenuId = `${workflowControlId}-menu`;
   const hasRestored = useRef(false);
@@ -829,6 +883,13 @@ export default function VideoStudio({
   };
   const workflowMediaDraftsRef = useRef(workflowMediaDrafts);
   workflowMediaDraftsRef.current = workflowMediaDrafts;
+  const commonParameterValuesRef = useRef(null);
+  commonParameterValuesRef.current = {
+    aspectRatio: selectedAr,
+    duration: selectedDuration,
+    resolution: selectedResolution,
+    quality: selectedQuality,
+  };
 
   // ── derived data ──
   const history = historyItems ?? localHistory;
@@ -847,7 +908,9 @@ export default function VideoStudio({
 
   const getCurrentAspectRatios = useCallback(
     (id) =>
-      imageMode
+      getSeedanceConfiguration(id)
+        ? getSeedanceCommonOptions(videoModelCatalog.variantById.get(id)?.model).aspectRatios
+        : imageMode
         ? getAspectRatiosForI2VModel(id)
         : getAspectRatiosForVideoModel(id),
     [imageMode],
@@ -855,7 +918,9 @@ export default function VideoStudio({
 
   const getCurrentDurations = useCallback(
     (id) =>
-      imageMode ? getDurationsForI2VModel(id) : getDurationsForModel(id),
+      getSeedanceConfiguration(id)
+        ? getSeedanceCommonOptions(videoModelCatalog.variantById.get(id)?.model).durations
+        : imageMode ? getDurationsForI2VModel(id) : getDurationsForModel(id),
     [imageMode],
   );
 
@@ -884,6 +949,22 @@ export default function VideoStudio({
   // ── update controls when the selected model changes ─────────────────────
   const applyControlsForModel = useCallback(
     (modelId, isImageMode, isV2vMode) => {
+      if (getSeedanceConfiguration(modelId)) {
+        const model = videoModelCatalog.variantById.get(modelId)?.model;
+        const options = getSeedanceCommonOptions(model);
+        const values = getSeedanceCommonValues(model, commonParameterValuesRef.current);
+        setShowAr(options.aspectRatios.length > 0);
+        setShowDuration(options.durations.length > 0);
+        setShowResolution(options.resolutions.length > 0);
+        setShowQuality(options.qualities.length > 0);
+        setShowEffect(false);
+        if (values.aspectRatio !== undefined) setSelectedAr(values.aspectRatio);
+        if (values.duration !== undefined) setSelectedDuration(values.duration);
+        const resolution = values.resolution ?? getSeedanceEndpointResolution(modelId);
+        if (resolution !== undefined) setSelectedResolution(resolution);
+        if (values.quality !== undefined) setSelectedQuality(values.quality);
+        return;
+      }
       if (isV2vMode) {
         setShowAr(false);
         setShowDuration(false);
@@ -953,7 +1034,10 @@ export default function VideoStudio({
   const selectedWorkflow = selectedWorkflowId
     ? workflowFamily?.workflowById.get(selectedWorkflowId) || null
     : null;
-  const workflowControlState = getVideoWorkflowControlState(
+  const seedanceConfiguration = getSeedanceConfiguration(selectedModel);
+  const workflowControlState = seedanceConfiguration && workflowFamily
+    ? { kind: "menu", workflow: null }
+    : getVideoWorkflowControlState(
     workflowFamily,
     selectedModel,
   );
@@ -962,6 +1046,86 @@ export default function VideoStudio({
     : null;
   const selectedVariant = videoModelCatalog.variantById.get(selectedModel);
   const selectedPickerEntry = videoModelPickerEntryByVariantId.get(selectedModel);
+  const selectedTool = getSeedanceToolConfiguration(selectedModel);
+  const selectedPickerLabel = selectedTool
+    ? seedanceToolLabel(selectedTool, copy, true)
+    : selectedPickerEntry?.name || selectedFamily.name;
+  const getSeedancePlan = useCallback((options = {}) => planSeedanceSelection({
+    familyId: selectedFamilyId,
+    workflowId: selectedWorkflowId,
+    currentModelId: selectedModel,
+    nativeResolution: selectedResolution,
+    commonValues: {
+      aspectRatio: selectedAr, duration: selectedDuration,
+      resolution: selectedResolution, quality: selectedQuality,
+    },
+    ...options,
+  }), [selectedFamilyId, selectedWorkflowId, selectedModel, selectedResolution, selectedAr, selectedDuration, selectedQuality]);
+  const describeSeedanceAdjustments = useCallback((adjustments) => {
+    const valueLabel = (key, value) => {
+      if (key === "profile") return copy.seedance.profiles[value]?.label || value;
+      if (key === "speed") return copy.seedance.speeds[value] || value;
+      if (key === "resolution" && value === "default") return copy.seedance.defaultResolution;
+      return String(value).toLowerCase() === "4k" ? "4K" : value;
+    };
+    return adjustments.map(({ key, to }) =>
+      copy.seedance.adjustments[key].replace("{value}", valueLabel(key, to))).join(" · ");
+  }, [copy]);
+  const seedanceVariantOptions = useMemo(() => seedanceConfiguration
+    ? getSeedanceVariantOptions(selectedFamilyId, selectedWorkflowId, selectedModel)
+      .filter((field) => field.key !== "resolution")
+      .map((field) => ({
+        ...field,
+        options: field.options.map((option) => {
+          const plan = getSeedancePlan({ changes: { [field.key]: option.value } });
+          return {
+            ...option,
+            disabled: !plan,
+            adjustmentDescription: plan ? describeSeedanceAdjustments(plan.adjustments) : "",
+          };
+        }),
+      }))
+    : [], [seedanceConfiguration, selectedFamilyId, selectedWorkflowId, selectedModel, getSeedancePlan, describeSeedanceAdjustments, copy]);
+  const seedanceProfile = seedanceVariantOptions.find((field) => field.key === "profile");
+  const seedanceSpeed = seedanceVariantOptions.find((field) => field.key === "speed");
+  const seedanceResolution = useMemo(() => {
+    if (!seedanceConfiguration) return null;
+    const field = getSeedanceResolutionOptions(selectedFamilyId, selectedWorkflowId, selectedModel, selectedResolution, {
+      aspectRatio: selectedAr, duration: selectedDuration, quality: selectedQuality,
+    });
+    return {
+      ...field,
+      key: "resolution",
+      ...(!field.value && selectedWorkflowId !== "extend_uploaded_video"
+        ? { label: copy.seedance.defaultResolution } : {}),
+      options: field.options.map((option) => {
+        const adjustments = option.disabled ? [] : getSeedanceSelectionAdjustments({
+          currentModelId: selectedModel, nativeResolution: selectedResolution,
+          commonValues: { aspectRatio: selectedAr, duration: selectedDuration, quality: selectedQuality },
+          selection: option, changes: { resolution: option.value },
+        });
+        return { ...option, adjustmentDescription: describeSeedanceAdjustments(adjustments) };
+      }),
+    };
+  }, [seedanceConfiguration, selectedFamilyId, selectedWorkflowId, selectedModel, selectedResolution, selectedAr, selectedDuration, selectedQuality, describeSeedanceAdjustments, copy]);
+  const seedanceCommonOptions = useMemo(
+    () => getSeedanceCommonOptions(selectedVariant?.model), [selectedVariant],
+  );
+  const seedanceModes = useMemo(() => seedanceConfiguration && workflowFamily
+    ? [...(workflowFamily.hasBase ? [{ id: null }] : []), ...workflowFamily.workflows].map((workflow) => {
+        const plan = getSeedancePlan({ workflowId: workflow.id });
+        return {
+          id: workflow.id,
+          label: copy.seedance.modes[workflow.id || "text"],
+          description: getSeedanceModeDescription(
+            videoModelCatalog.variantById.get(plan?.selection.modelId)?.model,
+            workflow.id, copy.seedance,
+          ),
+          adjustmentDescription: plan ? describeSeedanceAdjustments(plan.adjustments) : "",
+          disabled: !plan,
+        };
+      })
+    : [], [seedanceConfiguration, workflowFamily, getSeedancePlan, describeSeedanceAdjustments, copy]);
   const activeWorkflowMediaDraft = useMemo(
     () => workflowMediaDraftKey
       ? projectVideoWorkflowMedia(
@@ -988,7 +1152,22 @@ export default function VideoStudio({
     [selectedVariant, selectedWorkflowId],
   );
   const currentModelCapabilities = getModelMediaCapabilities(selectedVariant?.model);
-  const supplementalInputs = getSupplementalModelInputs(selectedVariant?.model);
+  const supplementalInputs = useMemo(
+    () => {
+      const inputs = getSupplementalModelInputs(selectedVariant?.model);
+      return seedanceConfiguration
+        ? inputs.filter(({ key }) => key !== "omni_reference_task_type").map(({ key, schema }) => ({
+            key, schema: {
+              ...schema, ...copy.seedance.fields[key],
+              ...(key === "generate_audio" && selectedWorkflowId === "edit_video" ? copy.seedance.editAudio : {}),
+            },
+          }))
+        : inputs;
+    }, [selectedVariant, seedanceConfiguration, selectedWorkflowId, copy],
+  );
+  const handleModelParameterChange = useCallback((key, value) => {
+    setModelParameterValues((values) => ({ ...values, [key]: value }));
+  }, []);
 
   const applySelectedVariant = useCallback(
     (variant, mode, family, workflowId = null) => {
@@ -1075,7 +1254,7 @@ export default function VideoStudio({
         let restoredFamilyId = defaultFamily.id;
         if (data.selectedModel) {
           const restored = resolvePersistedVideoWorkflowSelection(
-            data.selectedModel,
+            migrateSeedanceResolutionSelection(data.selectedModel, data.selectedResolution),
             data.selectedWorkflowId || null,
             { hasEndFrame: Boolean(data.uploadedEndImageUrl) },
           );
@@ -1144,6 +1323,12 @@ export default function VideoStudio({
         if (data.localHistory) setLocalHistory(data.localHistory);
 
         // Update control visibility based on restored model/mode
+        commonParameterValuesRef.current = {
+          aspectRatio: data.selectedAr,
+          duration: data.selectedDuration,
+          resolution: data.selectedResolution,
+          quality: data.selectedQuality,
+        };
         applyControlsForModel(
           restoredModelId,
           restoredMode === "i2v",
@@ -1340,7 +1525,7 @@ export default function VideoStudio({
       setProgress(0);
       try {
         const progress = new Array(selectedFiles.length).fill(0);
-        return await Promise.all(
+        const results = await Promise.allSettled(
           selectedFiles.map((file, index) =>
             uploadFile(apiKey, file, (value) => {
               progress[index] = value;
@@ -1349,6 +1534,19 @@ export default function VideoStudio({
               );
             }),
           ),
+        );
+        const failures = results.flatMap((result, index) =>
+          result.status === "rejected"
+            ? [`${selectedFiles[index].name}: ${result.reason?.message || result.reason}`]
+            : [],
+        );
+        if (failures.length > 0) {
+          alert(copy.errors.labelUploadFailed
+            .replace('{label}', label)
+            .replace('{message}', failures.join('\n')));
+        }
+        return results.flatMap((result) =>
+          result.status === "fulfilled" ? [result.value] : [],
         );
       } catch (err) {
         console.error(`[VideoStudio] ${label} upload failed:`, err);
@@ -1359,7 +1557,7 @@ export default function VideoStudio({
         setProgress(0);
       }
     },
-    [apiKey],
+    [apiKey, copy.errors.labelExceedsLimit, copy.errors.labelUploadFailed],
   );
 
   const uploadWorkflowSlotFiles = useCallback(
@@ -1671,10 +1869,51 @@ export default function VideoStudio({
     setUploadedAudioUrls((urls) => urls.filter((_, itemIndex) => itemIndex !== index));
   };
 
+  const handleSeedanceSelection = useCallback((plan, family, workflowId) => {
+    if (!plan) {
+      toast.error(copy.seedance.incompatible);
+      return;
+    }
+    const { selection, adjustments } = plan;
+    const target = videoModelCatalog.variantById.get(selection.modelId);
+    applyUserSelectedVariant(target, target.mode, family, workflowId);
+    if (selection.resolution !== undefined) setSelectedResolution(selection.resolution);
+    if (adjustments.length) {
+      toast(describeSeedanceAdjustments(adjustments));
+    }
+  }, [applyUserSelectedVariant, describeSeedanceAdjustments, copy]);
+
   // ── model selection from dropdown ─────────────────────────────────────────
   const handleModelSelect = useCallback(
     (pickerEntry, category = "all") => {
       const { family, variantsByMode, defaultVariant } = pickerEntry;
+      if (pickerEntry.groupedSeedance) {
+        // Reopening the model picker must not reset a configured version.
+        if (family.id === selectedFamilyId &&
+            (category === "all" || (category === currentFamilyMode &&
+              (category !== "t2v" || !selectedWorkflowId))) &&
+            pickerEntry.variantIds.has(selectedModel)) return;
+        const candidate = category !== "all"
+          ? variantsByMode[category]
+          : variantsByMode[currentFamilyMode] || defaultVariant;
+        if (!candidate) return;
+        const targetFamily = getVideoWorkflowFamily(family.id);
+        const workflowId = category === "all" && selectedWorkflowId &&
+          targetFamily?.workflowById.has(selectedWorkflowId)
+          ? selectedWorkflowId
+          : inferVideoWorkflowId(family.id, candidate.model.id);
+        const remembered = workflowVariantPreferencesRef.current.get(
+          workflowContextKey(family.id, workflowId),
+        );
+        const plan = getSeedancePlan({
+          familyId: family.id,
+          workflowId,
+          currentModelId: family.id === selectedFamilyId ? selectedModel : remembered,
+          nativeResolution: family.id === selectedFamilyId ? selectedResolution : undefined,
+        });
+        handleSeedanceSelection(plan, family, workflowId);
+        return;
+      }
       const target = category !== "all"
         ? variantsByMode[category]
         : variantsByMode[currentFamilyMode] || defaultVariant;
@@ -1685,7 +1924,11 @@ export default function VideoStudio({
         const workflowId = targetWorkflowFamily.base.variantIds.has(target.model.id) ||
           targetWorkflowFamily.unmanagedVariantIds.has(target.model.id)
           ? null
-          : inferVideoWorkflowId(family.id, target.model.id);
+          : inferVideoWorkflowId(family.id, target.model.id, {
+              preferredWorkflowId: family.id === selectedFamilyId
+                ? selectedWorkflowId
+                : null,
+            });
         applyUserSelectedVariant(target, target.mode, family, workflowId);
         return;
       }
@@ -1694,11 +1937,21 @@ export default function VideoStudio({
     },
     [
       applyUserSelectedVariant,
+      handleSeedanceSelection,
+      getSeedancePlan,
       currentFamilyMode,
+      selectedFamilyId,
+      selectedWorkflowId,
+      selectedModel,
+      selectedResolution,
     ],
   );
 
   const handleWorkflowSelect = useCallback((workflowId) => {
+    if (getSeedanceConfiguration(selectedModel)) {
+      handleSeedanceSelection(getSeedancePlan({ workflowId }), selectedFamily, workflowId);
+      return;
+    }
     const preferred = workflowVariantPreferencesRef.current.get(
       workflowContextKey(selectedFamilyId, workflowId),
     );
@@ -1711,9 +1964,13 @@ export default function VideoStudio({
     if (target) {
       applyUserSelectedVariant(target, target.mode, selectedFamily, workflowId);
     }
-  }, [applyUserSelectedVariant, selectedFamily, selectedFamilyId, selectedModel]);
+  }, [applyUserSelectedVariant, selectedFamily, selectedFamilyId, selectedModel, getSeedancePlan, handleSeedanceSelection]);
 
   const clearWorkflow = useCallback(() => {
+    if (getSeedanceConfiguration(selectedModel)) {
+      handleSeedanceSelection(getSeedancePlan({ workflowId: null }), selectedFamily, null);
+      return;
+    }
     const preferred = workflowVariantPreferencesRef.current.get(
       workflowContextKey(selectedFamilyId, null),
     );
@@ -1723,7 +1980,24 @@ export default function VideoStudio({
       preferred,
     );
     if (target) applyUserSelectedVariant(target, target.mode, selectedFamily, null);
-  }, [applyUserSelectedVariant, selectedFamily, selectedFamilyId, selectedModel]);
+  }, [applyUserSelectedVariant, selectedFamily, selectedFamilyId, selectedModel, getSeedancePlan, handleSeedanceSelection]);
+
+  const handleSeedanceOptionChange = useCallback((key, value) => {
+    handleSeedanceSelection(getSeedancePlan({ changes: { [key]: value } }), selectedFamily, selectedWorkflowId);
+  }, [selectedFamily, selectedWorkflowId, getSeedancePlan, handleSeedanceSelection]);
+
+  const handleSeedanceResolutionChange = useCallback((option) => {
+    if (option.disabled) return;
+    const adjustments = getSeedanceSelectionAdjustments({
+      currentModelId: selectedModel,
+      nativeResolution: selectedResolution,
+      commonValues: commonParameterValuesRef.current,
+      selection: option,
+      changes: { resolution: option.value },
+    });
+    handleSeedanceSelection({ selection: option, adjustments }, selectedFamily, selectedWorkflowId);
+    setOpenDropdown(null);
+  }, [handleSeedanceSelection, selectedFamily, selectedWorkflowId, selectedModel, selectedResolution]);
 
   // ── add to local history ──────────────────────────────────────────────────
   const addToLocalHistory = useCallback((entry) => {
@@ -1740,7 +2014,26 @@ export default function VideoStudio({
 
   // ── generate ──────────────────────────────────────────────────────────────
   const handleGenerate = useCallback(async () => {
+    if (mediaUploading || workflowUploadSlotRef.current) {
+      toast.error(copy.errors.waitForCurrentUpload);
+      return;
+    }
     const currentModel = getCurrentModel();
+    const seedance = getSeedanceConfiguration(selectedModel);
+    const generationParameterValues = seedance && currentModel.inputs?.omni_reference_task_type
+      ? { ...modelParameterValues, omni_reference_task_type: "auto" }
+      : modelParameterValues;
+    const seedanceCommonParams = seedance
+      ? buildSeedanceCommonPayload(currentModel, {
+          aspectRatio: selectedAr, duration: selectedDuration,
+          resolution: selectedResolution, quality: selectedQuality,
+        })
+      : {};
+    const seedanceHistorySettings = seedance ? {
+      ...seedanceCommonParams,
+      workflowId: selectedWorkflowId,
+      modelParameterValues: { ...generationParameterValues },
+    } : {};
     const isExtendMode = currentModel?.requiresRequestId;
     const capabilities = getModelMediaCapabilities(currentModel);
     const requestSource = generationSources[selectedFamily.id];
@@ -1791,8 +2084,8 @@ export default function VideoStudio({
         return;
       }
     } else if (isExtendMode) {
-      if (!requestSource?.requestId) {
-        alert(`No ${selectedFamily.name} generation found to continue.`);
+      if (!requestSource?.requestId || (selectedFamily.id === "seedance-2" && !isContinuationSourceModel(currentModel, requestSource.modelId))) {
+        alert(copy.errors.noContinuationSource.replace("{family}", selectedFamily.name));
         return;
       }
     } else if (imageMode) {
@@ -1828,7 +2121,8 @@ export default function VideoStudio({
         // remover) and motion-control models (which take video + image + prompt)
         const v2vParams = {
           model: selectedModel,
-          ...buildSupplementalInputPayload(currentModel, modelParameterValues),
+          ...buildSupplementalInputPayload(currentModel, generationParameterValues),
+          ...seedanceCommonParams,
           ...referenceParams,
         };
         if (currentModel?.hasPrompt && trimmedPrompt) {
@@ -1843,6 +2137,7 @@ export default function VideoStudio({
           url: res.url,
           prompt: currentModel?.hasPrompt ? trimmedPrompt : "",
           model: selectedModel,
+          ...seedanceHistorySettings,
           timestamp: new Date().toISOString(),
         };
         addToLocalHistory(entry);
@@ -1857,17 +2152,18 @@ export default function VideoStudio({
       } else if (imageMode) {
         const i2vParams = {
           model: selectedModel,
-          ...buildSupplementalInputPayload(currentModel, modelParameterValues),
+          ...buildSupplementalInputPayload(currentModel, generationParameterValues),
+          ...seedanceCommonParams,
           ...referenceParams,
         };
         if (trimmedPrompt) i2vParams.prompt = trimmedPrompt;
         const aspectRatios = getAspectRatiosForI2VModel(selectedModel);
-        if (aspectRatios.length > 0) i2vParams.aspect_ratio = selectedAr;
+        if (!seedance && aspectRatios.length > 0) i2vParams.aspect_ratio = selectedAr;
         const durations = getDurationsForI2VModel(selectedModel);
-        if (durations.length > 0) i2vParams.duration = selectedDuration;
+        if (!seedance && durations.length > 0) i2vParams.duration = selectedDuration;
         const resolutions = getResolutionsForI2VModel(selectedModel);
-        if (resolutions.length > 0) i2vParams.resolution = selectedResolution;
-        if (selectedQuality) i2vParams.quality = selectedQuality;
+        if (!seedance && resolutions.length > 0) i2vParams.resolution = selectedResolution;
+        if (!seedance && selectedQuality) i2vParams.quality = selectedQuality;
         if (showEffect && selectedEffect) i2vParams.name = selectedEffect;
 
         res = await generateI2V(apiKey, i2vParams);
@@ -1884,6 +2180,7 @@ export default function VideoStudio({
           model: selectedModel,
           ...(aspectRatios.length > 0 ? { aspect_ratio: selectedAr } : {}),
           duration: selectedDuration,
+          ...seedanceHistorySettings,
           timestamp: new Date().toISOString(),
         };
         addToLocalHistory(entry);
@@ -1899,22 +2196,23 @@ export default function VideoStudio({
         // T2V (including extend mode)
         const params = {
           model: selectedModel,
-          ...buildSupplementalInputPayload(currentModel, modelParameterValues),
+          ...buildSupplementalInputPayload(currentModel, generationParameterValues),
+          ...seedanceCommonParams,
           ...referenceParams,
         };
         if (trimmedPrompt) params.prompt = trimmedPrompt;
 
         if (isExtendMode) {
           params.request_id = requestSource.requestId;
-        } else {
+        } else if (!seedance) {
           params.aspect_ratio = selectedAr;
         }
 
         const durations = getDurationsForModel(selectedModel);
-        if (durations.length > 0) params.duration = selectedDuration;
+        if (!seedance && durations.length > 0) params.duration = selectedDuration;
         const resolutions = getResolutionsForVideoModel(selectedModel);
-        if (resolutions.length > 0) params.resolution = selectedResolution;
-        if (selectedQuality) params.quality = selectedQuality;
+        if (!seedance && resolutions.length > 0) params.resolution = selectedResolution;
+        if (!seedance && selectedQuality) params.quality = selectedQuality;
 
         res = await generateVideo(apiKey, params);
         if (!res?.url) throw new Error(copy.errors.noVideoUrlReturned);
@@ -1930,6 +2228,7 @@ export default function VideoStudio({
           model: selectedModel,
           aspect_ratio: selectedAr,
           duration: selectedDuration,
+          ...seedanceHistorySettings,
           timestamp: new Date().toISOString(),
         };
         addToLocalHistory(entry);
@@ -1953,6 +2252,7 @@ export default function VideoStudio({
     }
   }, [
     apiKey,
+    copy,
     prompt,
     v2vMode,
     imageMode,
@@ -1972,6 +2272,7 @@ export default function VideoStudio({
     uploadedAudioUrls,
     activeWorkflowMediaDraft,
     generationSources,
+    mediaUploading,
     getCurrentModel,
     addToLocalHistory,
     showVideoInCanvas,
@@ -2020,10 +2321,11 @@ export default function VideoStudio({
   }, [applyUserSelectedVariant, resetToPromptBar]);
 
   // ── derived UI values ────────────────────────────────────────────────────
-  const isSeedance2Canvas =
-    videoModelCatalog.familyByVariantId.get(canvasModel)?.id === "seedance-2";
   const currentModelObj = selectedVariant?.model;
   const isExtendMode = currentModelObj?.requiresRequestId;
+  const continuationSource = generationSources[selectedFamily.id];
+  const hasContinuationSource = continuationSource?.requestId &&
+    (!selectedTool || isContinuationSourceModel(currentModelObj, continuationSource.modelId));
   const isMotionControlModel = isMotionControlSelection(selectedModel, v2vMode);
   const workflowMediaConfig = selectedWorkflowId
     ? getVideoWorkflowMediaConfig(currentModelObj, selectedWorkflowId)
@@ -2080,99 +2382,19 @@ export default function VideoStudio({
               ? copy.placeholders.optionalContinueVideo
               : copy.placeholders.describeVideo;
 
-  const focusWorkflowMenuItem = useCallback((target = "selected") => {
-    const items = Array.from(
-      workflowMenuRef.current?.querySelectorAll(
-        '[role="menuitemradio"], [role="menuitem"]',
-      ) || [],
-    );
-    if (items.length === 0) return;
-
-    const item = target === "last"
-      ? items[items.length - 1]
-      : target === "first"
-        ? items[0]
-        : items.find((candidate) => candidate.getAttribute("aria-checked") === "true") ||
-          items[0];
-    item.focus();
-  }, []);
-
-  const closeWorkflowMenu = useCallback((restoreFocus = false) => {
-    setOpenDropdown(null);
-    if (restoreFocus) {
-      requestAnimationFrame(() => workflowTriggerRef.current?.focus());
-    }
-  }, []);
-
-  const handleWorkflowTriggerKeyDown = useCallback(
-    (event) => {
-      const focusTarget = event.key === "ArrowUp" || event.key === "End"
-        ? "last"
-        : event.key === "ArrowDown" || event.key === "Home"
-          ? "first"
-          : null;
-      if (!focusTarget) return;
-
-      event.preventDefault();
-      event.stopPropagation();
-      if (openDropdown === "workflow") {
-        focusWorkflowMenuItem(focusTarget);
-        return;
-      }
-      workflowMenuFocusTargetRef.current = focusTarget;
-      setOpenDropdown("workflow");
-    },
-    [focusWorkflowMenuItem, openDropdown],
-  );
-
-  const handleWorkflowMenuKeyDown = useCallback(
-    (event) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        event.stopPropagation();
-        closeWorkflowMenu(true);
-        return;
-      }
-      if (event.key === "Tab") {
-        setOpenDropdown(null);
-        return;
-      }
-      if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
-
-      const items = Array.from(
-        workflowMenuRef.current?.querySelectorAll(
-          '[role="menuitemradio"], [role="menuitem"]',
-        ) || [],
-      );
-      if (items.length === 0) return;
-
-      event.preventDefault();
-      event.stopPropagation();
-      const currentIndex = items.indexOf(document.activeElement);
-      const nextIndex = event.key === "Home"
-        ? 0
-        : event.key === "End"
-          ? items.length - 1
-          : event.key === "ArrowDown"
-            ? currentIndex < 0
-              ? 0
-              : (currentIndex + 1) % items.length
-            : currentIndex < 0
-              ? items.length - 1
-              : (currentIndex - 1 + items.length) % items.length;
-      items[nextIndex].focus();
-    },
-    [closeWorkflowMenu],
-  );
-
-  useEffect(() => {
-    if (openDropdown !== "workflow") return undefined;
-    const frame = requestAnimationFrame(() => {
-      focusWorkflowMenuItem(workflowMenuFocusTargetRef.current);
-      workflowMenuFocusTargetRef.current = "selected";
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [focusWorkflowMenuItem, openDropdown, selectedWorkflowId]);
+  const {
+    triggerRef: workflowTriggerRef,
+    menuRef: workflowMenuRef,
+    focusTargetRef: workflowMenuFocusTargetRef,
+    onTriggerKeyDown: handleWorkflowTriggerKeyDown,
+    onMenuKeyDown: handleWorkflowMenuKeyDown,
+    closeMenu: closeWorkflowMenu,
+  } = usePromptMenu({
+    open: openDropdown === "workflow",
+    onOpen: () => setOpenDropdown("workflow"),
+    onClose: () => setOpenDropdown(null),
+    selectionKey: selectedWorkflowId,
+  });
 
   const toggleDropdown = (type) => (e) => {
     e.stopPropagation();
@@ -2190,7 +2412,7 @@ export default function VideoStudio({
         {history.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 w-full pt-4 animate-fade-in-up">
             {history.map((entry, idx) => {
-              const isSeedance2 = entry.model === "seedance-v2.0-t2v" || entry.model === "seedance-v2.0-i2v";
+              const isSeedance2 = isContinuationSourceModel("seedance-2-extend", entry.model);
               return (
                 <div
                   key={entry.id || idx}
@@ -2356,14 +2578,18 @@ export default function VideoStudio({
             </div>
 
             <h1 className="text-2xl sm:text-4xl md:text-5xl font-extrabold tracking-tight mb-4 text-center px-4 flex flex-col items-center">
-              <span className="text-white font-black uppercase text-xl sm:text-3xl tracking-wide mb-1 opacity-90">{copy.empty.heading}</span>
+              {!selectedTool && <span className="text-white font-black uppercase text-xl sm:text-3xl tracking-wide mb-1 opacity-90">{copy.empty.heading}</span>}
               <span className="text-[#22d3ee] font-black uppercase text-2xl sm:text-4xl sm:mt-1 tracking-tight">
-                {selectedFamily.name}
+                {selectedTool || selectedPickerEntry?.groupedSeedance ? selectedPickerLabel : selectedFamily.name}
               </span>
             </h1>
-            <p className="text-white/40 text-xs sm:text-sm font-medium tracking-wide text-center max-w-lg leading-relaxed px-4">
-              {copy.empty.subtitle}
-            </p>
+            {!selectedTool && (
+              <p className="text-white/40 text-xs sm:text-sm font-medium tracking-wide text-center max-w-lg leading-relaxed px-4">
+                {seedanceConfiguration
+                  ? getSeedanceModeDescription(selectedVariant.model, selectedWorkflowId, copy.seedance)
+                  : copy.empty.subtitle}
+              </p>
+            )}
           </div>
         )}
       </div>
@@ -2595,8 +2821,20 @@ export default function VideoStudio({
               >
                 <path d="M5 12h14M12 5l7 7-7 7" />
               </svg>
-              <span>{copy.extend.continuingGeneration.replace('{family}', selectedFamily.name)}</span>
+              <span>{hasContinuationSource
+                ? copy.extend.continuingGeneration.replace('{family}', selectedFamily.name)
+                : copy.errors.noContinuationSource.replace("{family}", selectedFamily.name)}</span>
             </div>
+          )}
+
+          {seedanceConfiguration && selectedVariant.model.aspectRatioMode === "inherited" && (
+            <p className="px-2 text-[10px] text-white/40">{copy.seedance.inheritedFormat}</p>
+          )}
+          {seedanceConfiguration && selectedWorkflowId === "extend_uploaded_video" && seedanceResolution.options.length === 0 && (
+            <p className="px-2 text-[10px] text-white/40">{copy.seedance.inheritedVideoResolution}</p>
+          )}
+          {seedanceResolution?.label && (
+            <p className="px-2 text-[10px] text-white/40">{copy.seedance.resolutionUnknown}</p>
           )}
 
           {/* Bottom row: controls + generate */}
@@ -2626,7 +2864,7 @@ export default function VideoStudio({
                     })()}
                 </div>
                 <span className={PROMPT_CONTROL_LABEL_CLASS}>
-                    {selectedPickerEntry?.name || selectedFamily.name}
+                    {selectedPickerLabel}
                   </span>
                   <PromptChevronIcon />
                 </button>
@@ -2634,6 +2872,8 @@ export default function VideoStudio({
                   <PromptPopover
                     onClick={(e) => e.stopPropagation()}
                     className="w-[calc(100vw-2rem)] md:w-[480px] max-w-md md:max-w-none max-h-[70vh]"
+                    fitViewport={Boolean(seedanceConfiguration)}
+                    solid={Boolean(seedanceConfiguration)}
                   >
                     <PromptPopoverHeader>{copy.dropdowns.model}</PromptPopoverHeader>
                     <ModelDropdown
@@ -2697,14 +2937,18 @@ export default function VideoStudio({
                     })}
                   >
                     <span className={PROMPT_CONTROL_LABEL_CLASS}>
-                      {getVideoWorkflowControlLabel(selectedWorkflow)}
+                      {seedanceConfiguration
+                        ? copy.seedance.modes[selectedWorkflowId || "text"]
+                        : getVideoWorkflowControlLabel(selectedWorkflow)}
                     </span>
                     {workflowControlState.kind === "menu" && <PromptChevronIcon />}
                   </button>
                   {workflowControlState.kind === "menu" && openDropdown === "workflow" && (
                     <PromptPopover
-                      className="min-w-[210px]"
-                      style={{ maxHeight: "55vh" }}
+                      className={seedanceConfiguration ? "w-[300px] max-w-[calc(100vw-32px)]" : "min-w-[210px]"}
+                      fitViewport={Boolean(seedanceConfiguration)}
+                      solid={Boolean(seedanceConfiguration)}
+                      style={{ maxHeight: seedanceConfiguration ? "65vh" : "55vh" }}
                       onClick={(event) => event.stopPropagation()}
                     >
                       <PromptPopoverHeader>{copy.dropdowns.source}</PromptPopoverHeader>
@@ -2716,20 +2960,32 @@ export default function VideoStudio({
                         onKeyDown={handleWorkflowMenuKeyDown}
                         className="flex flex-col gap-1"
                       >
-                        {workflowFamily.workflows.map((workflow) => (
+                        {(seedanceConfiguration ? seedanceModes : workflowFamily.workflows).map((workflow) => (
                           <PromptMenuItem
-                            key={workflow.id}
+                            key={workflow.id || "text"}
                             selected={selectedWorkflowId === workflow.id}
+                            disabled={workflow.disabled}
+                            wrapDescription={Boolean(seedanceConfiguration)}
+                            description={seedanceConfiguration && (
+                              <>
+                                {workflow.description}
+                                {workflow.adjustmentDescription && (
+                                  <span className="mt-1 block text-amber-200/85">{workflow.adjustmentDescription}</span>
+                                )}
+                              </>
+                            )}
+                            className="disabled:opacity-40 disabled:cursor-not-allowed"
                             onClick={(event) => {
                               event.stopPropagation();
-                              handleWorkflowSelect(workflow.id);
+                              if (workflow.id === null) clearWorkflow();
+                              else handleWorkflowSelect(workflow.id);
                               closeWorkflowMenu(true);
                             }}
                           >
                             {workflow.label}
                           </PromptMenuItem>
                         ))}
-                        {selectedWorkflow && workflowFamily?.hasBase && (
+                        {!seedanceConfiguration && selectedWorkflow && workflowFamily?.hasBase && (
                           <div className="mt-2 border-t border-white/[0.05] pt-2">
                             <button
                               type="button"
@@ -2766,15 +3022,43 @@ export default function VideoStudio({
                 </div>
               )}
 
-              <ModelParameterControls
-                inputs={supplementalInputs}
-                values={modelParameterValues}
-                onChange={(key, value) =>
-                  setModelParameterValues((values) => ({ ...values, [key]: value }))
-                }
-                open={openDropdown === "parameters"}
-                onToggle={toggleDropdown("parameters")}
+              <SeedanceOptionControl
+                label={copy.seedance.speed}
+                field={seedanceSpeed}
+                open={openDropdown === "seedance-speed"}
+                onToggle={toggleDropdown("seedance-speed")}
+                onSelect={(option) => {
+                  handleSeedanceOptionChange("speed", option.value);
+                  setOpenDropdown(null);
+                }}
+                copy={copy.seedance}
               />
+
+              {seedanceConfiguration ? (
+                <SeedanceSettingsControl
+                  profile={seedanceProfile}
+                  onDefaultResolution={seedanceConfiguration.profile === "legacy" && seedanceConfiguration.resolution !== "default"
+                    ? () => handleSeedanceOptionChange("resolution", "default") : undefined}
+                  qualities={seedanceCommonOptions.qualities}
+                  quality={selectedQuality}
+                  onProfileChange={(value) => handleSeedanceOptionChange("profile", value)}
+                  onQualityChange={setSelectedQuality}
+                  inputs={supplementalInputs}
+                  values={modelParameterValues}
+                  onChange={handleModelParameterChange}
+                  open={openDropdown === "parameters"}
+                  onToggle={toggleDropdown("parameters")}
+                  copy={copy.seedance}
+                />
+              ) : (
+                <ModelParameterControls
+                  inputs={supplementalInputs}
+                  values={modelParameterValues}
+                  onChange={handleModelParameterChange}
+                  open={openDropdown === "parameters"}
+                  onToggle={toggleDropdown("parameters")}
+                />
+              )}
 
               {/* Aspect ratio btn */}
               {showAr && (
@@ -2891,7 +3175,9 @@ export default function VideoStudio({
                       onClick={(e) => e.stopPropagation()}
                     >
                       <PromptPopoverHeader>
-                        {copy.dropdowns.duration}
+                        {seedanceConfiguration && selectedWorkflowId === "extend_uploaded_video"
+                          ? copy.seedance.extensionDuration
+                          : copy.dropdowns.duration}
                       </PromptPopoverHeader>
                       <PromptMenuList>
                         {getCurrentDurations(selectedModel).map((d) => (
@@ -2914,7 +3200,16 @@ export default function VideoStudio({
               )}
 
               {/* Resolution btn */}
-              {showResolution && (
+              <SeedanceOptionControl
+                label={copy.dropdowns.resolution}
+                field={seedanceResolution}
+                icon={<PromptQualityIcon />}
+                open={openDropdown === "resolution"}
+                onToggle={toggleDropdown("resolution")}
+                onSelect={handleSeedanceResolutionChange}
+                copy={copy.seedance}
+              />
+              {!seedanceConfiguration && showResolution && (
                 <div className="relative">
                   <button
                     type="button"
@@ -2981,7 +3276,7 @@ export default function VideoStudio({
             {/* Generate button */}
             <PromptAction
               onClick={handleGenerate}
-              disabled={generating}
+              disabled={generating || mediaUploading || (selectedTool?.group === "continueGenerated" && !hasContinuationSource)}
             >
               {generating ? (
                 <>

--- a/packages/studio/src/components/prompt/PromptComposer.jsx
+++ b/packages/studio/src/components/prompt/PromptComposer.jsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
 } from "react";
 
@@ -36,7 +37,7 @@ const DEFAULT_POPOVER_POSITION_CLASS =
   "absolute bottom-[calc(100%+12px)] left-0 z-50";
 
 const DEFAULT_POPOVER_CLASS =
-  "bg-[#0c0c0f]/95 rounded-xl p-3.5 shadow-[0_10px_40px_rgba(0,0,0,0.8)] border border-white/[0.08] backdrop-blur-2xl min-w-[160px] max-h-[40vh] overflow-y-auto custom-scrollbar";
+  "rounded-xl p-3.5 shadow-[0_10px_40px_rgba(0,0,0,0.8)] border border-white/[0.08] backdrop-blur-2xl min-w-[160px] max-h-[40vh] overflow-y-auto custom-scrollbar";
 
 function joinClasses(...classes) {
   return classes.filter(Boolean).join(" ");
@@ -165,17 +166,35 @@ export const PromptPopover = forwardRef(function PromptPopover(
     children,
     className = "",
     positionClassName = DEFAULT_POPOVER_POSITION_CLASS,
+    fitViewport = false,
+    solid = false,
     ...props
   },
   ref,
 ) {
+  const popoverRef = useRef(null);
+  useImperativeHandle(ref, () => popoverRef.current);
+  useLayoutEffect(() => {
+    if (!fitViewport) return;
+    const position = () => {
+      const popover = popoverRef.current;
+      popover.style.translate = "";
+      const bounds = popover.getBoundingClientRect();
+      const shift = Math.max(16 - bounds.left, Math.min(0, window.innerWidth - 16 - bounds.right));
+      popover.style.translate = `${shift}px 0`;
+    };
+    position();
+    window.addEventListener("resize", position);
+    return () => window.removeEventListener("resize", position);
+  }, [fitViewport, children]);
   return (
     <div
       {...props}
-      ref={ref}
+      ref={popoverRef}
       className={joinClasses(
         positionClassName,
         DEFAULT_POPOVER_CLASS,
+        solid ? "bg-[#0c0c0f]" : "bg-[#0c0c0f]/95",
         className,
       )}
     >
@@ -208,6 +227,7 @@ export function PromptMenuList({ children, className = "" }) {
 export function PromptMenuItem({
   children,
   description,
+  wrapDescription = false,
   selected = false,
   className = "",
   type = "button",
@@ -228,7 +248,12 @@ export function PromptMenuItem({
       <span className="min-w-0">
         <span className="block truncate">{children}</span>
         {description && (
-          <span className="block text-[9px] font-medium text-white/35 mt-0.5 truncate group-hover/menu-item:text-white/50">
+          <span className={joinClasses(
+            "block font-medium mt-0.5",
+            wrapDescription
+              ? "text-[10px] leading-relaxed whitespace-normal text-white/55 group-hover/menu-item:text-white/70"
+              : "text-[9px] text-white/35 truncate group-hover/menu-item:text-white/50",
+          )}>
             {description}
           </span>
         )}

--- a/packages/studio/src/components/prompt/usePromptMenu.js
+++ b/packages/studio/src/components/prompt/usePromptMenu.js
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+const MENU_ITEMS = '[role="menuitemradio"]:not(:disabled), [role="menuitem"]:not(:disabled)';
+
+export default function usePromptMenu({ open, onOpen, onClose, selectionKey }) {
+  const triggerRef = useRef(null);
+  const menuRef = useRef(null);
+  const focusTargetRef = useRef("selected");
+  const getItems = useCallback(() => Array.from(
+    menuRef.current?.querySelectorAll(MENU_ITEMS) || [],
+  ), []);
+  const focusItem = useCallback((target = "selected") => {
+    const items = getItems();
+    const item = target === "last"
+      ? items[items.length - 1]
+      : target === "first"
+        ? items[0]
+        : items.find((candidate) => candidate.getAttribute("aria-checked") === "true") || items[0];
+    item?.focus();
+  }, [getItems]);
+  const restoreFocus = useCallback(() => {
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  }, []);
+  const closeMenu = useCallback((restore = false, event) => {
+    onClose(event);
+    if (restore) restoreFocus();
+  }, [onClose, restoreFocus]);
+
+  const onTriggerKeyDown = useCallback((event) => {
+    const target = event.key === "ArrowUp" || event.key === "End"
+      ? "last"
+      : event.key === "ArrowDown" || event.key === "Home"
+        ? "first"
+        : null;
+    if (!target) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (open) {
+      focusItem(target);
+    } else {
+      focusTargetRef.current = target;
+      onOpen(event);
+    }
+  }, [focusItem, onOpen, open]);
+
+  const onMenuKeyDown = useCallback((event) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      closeMenu(true, event);
+      return;
+    }
+    if (event.key === "Tab") {
+      closeMenu(false, event);
+      return;
+    }
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+
+    const items = getItems();
+    if (items.length === 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const currentIndex = items.indexOf(document.activeElement);
+    const nextIndex = event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? items.length - 1
+        : event.key === "ArrowDown"
+          ? currentIndex < 0 ? 0 : (currentIndex + 1) % items.length
+          : currentIndex < 0 ? items.length - 1 : (currentIndex - 1 + items.length) % items.length;
+    items[nextIndex].focus();
+  }, [closeMenu, getItems]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const frame = requestAnimationFrame(() => {
+      focusItem(focusTargetRef.current);
+      focusTargetRef.current = "selected";
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [focusItem, open, selectionKey]);
+
+  return {
+    triggerRef, menuRef, focusTargetRef, onTriggerKeyDown, onMenuKeyDown,
+    closeMenu, restoreFocus,
+  };
+}

--- a/packages/studio/src/messages/en/videoStudio.json
+++ b/packages/studio/src/messages/en/videoStudio.json
@@ -37,7 +37,7 @@
   },
   "dropdowns": {
     "model": "Model",
-    "source": "Source",
+    "source": "Video mode",
     "baseGeneration": "Base generation",
     "aspectRatio": "Aspect Ratio",
     "effect": "Effect",
@@ -87,6 +87,126 @@
     "enterPromptToGenerate": "Please enter a prompt to generate a video.",
     "noVideoUrlReturned": "No video URL returned by API",
     "videoGenerationFailed": "Video generation failed",
-    "deleteItemFailed": "Failed to delete item"
+    "deleteItemFailed": "Failed to delete item",
+    "noContinuationSource": "Choose a compatible {family} result to continue."
+  },
+  "seedance": {
+    "modes": {
+      "text": "From prompt",
+      "animate_image": "Animate image",
+      "keyframes": "Start & end frames",
+      "references": "Use references",
+      "edit_video": "Edit video",
+      "extend_uploaded_video": "Extend video"
+    },
+    "settings": "Settings",
+    "speed": "Speed",
+    "speeds": {
+      "standard": "Standard speed",
+      "fast": "Fast"
+    },
+    "quality": "Quality",
+    "extensionDuration": "Extension duration",
+    "defaultResolution": "Service default",
+    "incompatible": "This choice is unavailable for this model version.",
+    "incompatibleShort": "Unavailable for this version",
+    "inheritedFormat": "Format follows the source image",
+    "tools": "Seedance video tools",
+    "inheritedVideoResolution": "Resolution follows the source video",
+    "modeDescriptions": {
+      "text": "Create a video from your description.",
+      "animate_image": "Animate an uploaded image using your description.",
+      "keyframes": "Create a video between two images you choose.",
+      "references": "Create a video using uploaded files as guides.",
+      "edit_video": "Upload a video and describe your changes.",
+      "extend_uploaded_video": "Add new footage to the end of an uploaded video."
+    },
+    "profiles": {
+      "standard": {
+        "label": "Standard",
+        "description": ""
+      },
+      "intl": {
+        "label": "International",
+        "description": "International deployment."
+      },
+      "vip": {
+        "label": "VIP",
+        "description": "Priority processing."
+      },
+      "mini": {
+        "label": "Mini",
+        "description": "Lighter model."
+      },
+      "spicy": {
+        "label": "Spicy",
+        "description": "Bolder contrast and motion."
+      },
+      "mini_spicy": {
+        "label": "Mini Spicy",
+        "description": ""
+      },
+      "legacy": {
+        "label": "Seedance 2.0 API",
+        "description": ""
+      },
+      "legacy_new": {
+        "label": "Seedance 2.0 New API",
+        "description": ""
+      }
+    },
+    "defaultVariant": "Default",
+    "continueGenerated": "Continue a Seedance 2.0 result",
+    "removeWatermark": "Remove watermark",
+    "advanced": "Advanced",
+    "adjustments": {
+      "resolution": "Uses {value}",
+      "duration": "Duration: {value} s",
+      "aspectRatio": "Format: {value}",
+      "speed": "Speed: {value}",
+      "profile": "Service: {value}",
+      "quality": "Quality: {value}"
+    },
+    "fields": {
+      "seed": {
+        "title": "Seed",
+        "description": "Use −1 for random results."
+      },
+      "high_bitrate": {
+        "title": "High bitrate",
+        "description": "Larger files, more detail."
+      },
+      "generate_audio": {
+        "title": "Generate audio",
+        "description": ""
+      },
+      "camera_fixed": {
+        "title": "Fixed camera",
+        "description": "Keep the camera still."
+      }
+    },
+    "toolNames": {
+      "continueGenerated": "Continue Seedance 2.0",
+      "removeWatermark": "Remove watermark"
+    },
+    "toolVariants": {
+      "standard": "Standard",
+      "vip": "VIP",
+      "pro": "Pro"
+    },
+    "provider": "Generation service",
+    "providerHelp": "Choose a specific service when needed.",
+    "resolutionUnknown": "Output resolution is not specified by this service.",
+    "referenceSupport": "Supports: {media}.",
+    "referenceMediaTypes": {
+      "image": "Images",
+      "video": "Video",
+      "audio": "Audio"
+    },
+    "editAudio": {
+      "title": "New audio",
+      "description": "Off keeps the original audio."
+    },
+    "restoreDefaultResolution": "Use the service’s default output size"
   }
 }

--- a/packages/studio/src/messages/zh/videoStudio.json
+++ b/packages/studio/src/messages/zh/videoStudio.json
@@ -37,7 +37,7 @@
   },
   "dropdowns": {
     "model": "模型",
-    "source": "来源",
+    "source": "视频模式",
     "baseGeneration": "基础生成",
     "aspectRatio": "宽高比",
     "effect": "特效",
@@ -87,6 +87,126 @@
     "enterPromptToGenerate": "请输入提示词以生成视频。",
     "noVideoUrlReturned": "API 未返回视频链接",
     "videoGenerationFailed": "视频生成失败",
-    "deleteItemFailed": "删除项目失败"
+    "deleteItemFailed": "删除项目失败",
+    "noContinuationSource": "请选择兼容的 {family} 结果继续生成。"
+  },
+  "seedance": {
+    "modes": {
+      "text": "文字生成",
+      "animate_image": "图片动画",
+      "keyframes": "起始与结束帧",
+      "references": "使用参考素材",
+      "edit_video": "编辑视频",
+      "extend_uploaded_video": "延长视频"
+    },
+    "settings": "设置",
+    "speed": "速度",
+    "speeds": {
+      "standard": "标准速度",
+      "fast": "快速"
+    },
+    "quality": "质量",
+    "extensionDuration": "续接片段时长",
+    "defaultResolution": "服务默认值",
+    "incompatible": "此模型版本不支持该选择。",
+    "incompatibleShort": "此版本不支持",
+    "inheritedFormat": "画面比例继承自原始图片",
+    "tools": "Seedance 视频工具",
+    "inheritedVideoResolution": "分辨率继承自原始视频",
+    "modeDescriptions": {
+      "text": "根据你的描述生成视频。",
+      "animate_image": "根据你的描述，让上传的图片动起来。",
+      "keyframes": "用你选定的两张图片作为首尾帧生成视频。",
+      "references": "参考上传的素材生成视频。",
+      "edit_video": "上传视频并描述你想修改的内容。",
+      "extend_uploaded_video": "在上传的视频末尾添加新的片段。"
+    },
+    "profiles": {
+      "standard": {
+        "label": "标准版",
+        "description": ""
+      },
+      "intl": {
+        "label": "国际版",
+        "description": "国际部署。"
+      },
+      "vip": {
+        "label": "VIP 版",
+        "description": "优先处理。"
+      },
+      "mini": {
+        "label": "Mini 版",
+        "description": "轻量模型。"
+      },
+      "spicy": {
+        "label": "Spicy 版",
+        "description": "更鲜明的对比和运动效果。"
+      },
+      "mini_spicy": {
+        "label": "Mini Spicy 版",
+        "description": ""
+      },
+      "legacy": {
+        "label": "Seedance 2.0 API",
+        "description": ""
+      },
+      "legacy_new": {
+        "label": "Seedance 2.0 New API",
+        "description": ""
+      }
+    },
+    "defaultVariant": "默认",
+    "continueGenerated": "续接 Seedance 2.0 结果",
+    "removeWatermark": "去除水印",
+    "advanced": "高级",
+    "adjustments": {
+      "resolution": "使用 {value}",
+      "duration": "时长：{value} 秒",
+      "aspectRatio": "画面比例：{value}",
+      "speed": "速度：{value}",
+      "profile": "服务：{value}",
+      "quality": "质量：{value}"
+    },
+    "fields": {
+      "seed": {
+        "title": "随机种子",
+        "description": "设为 −1 使用随机结果。"
+      },
+      "high_bitrate": {
+        "title": "高码率",
+        "description": "更多细节，更大的文件。"
+      },
+      "generate_audio": {
+        "title": "生成音频",
+        "description": ""
+      },
+      "camera_fixed": {
+        "title": "固定镜头",
+        "description": "保持镜头静止。"
+      }
+    },
+    "toolNames": {
+      "continueGenerated": "续接 Seedance 2.0",
+      "removeWatermark": "去除水印"
+    },
+    "toolVariants": {
+      "standard": "标准版",
+      "vip": "VIP",
+      "pro": "Pro"
+    },
+    "provider": "生成服务",
+    "providerHelp": "有特定需要时，可选择指定服务。",
+    "resolutionUnknown": "此服务未指定输出分辨率。",
+    "referenceSupport": "支持：{media}。",
+    "referenceMediaTypes": {
+      "image": "图片",
+      "video": "视频",
+      "audio": "音频"
+    },
+    "editAudio": {
+      "title": "新音频",
+      "description": "关闭时保留原音频。"
+    },
+    "restoreDefaultResolution": "使用服务默认的输出分辨率"
   }
 }

--- a/packages/studio/src/modelCapabilities.js
+++ b/packages/studio/src/modelCapabilities.js
@@ -135,14 +135,16 @@ export function buildReferenceParams(
   return params;
 }
 
-function normalizedUrls(params, capability, singularParam, pluralParam) {
+function normalizedUrls(model, params, capability, singularParam, pluralParam) {
   if (!capability.field) return [];
   const direct = params[capability.field];
-  if (Array.isArray(direct) && direct.length > 0) return direct;
+  if (Array.isArray(direct)) return direct;
   if (direct) return [direct];
-  const plural = params[pluralParam];
+  // A separately declared media field has its own role (for example Wan's
+  // optional image_url anchor); it is not an alias for the primary input.
+  const plural = model?.inputs?.[pluralParam] ? undefined : params[pluralParam];
   if (Array.isArray(plural) && plural.length > 0) return plural;
-  const singular = params[singularParam];
+  const singular = model?.inputs?.[singularParam] ? undefined : params[singularParam];
   return singular ? [singular] : [];
 }
 
@@ -167,6 +169,7 @@ export function mapReferenceParams(model, params = {}) {
     const config = MEDIA_CONFIG[mediaType];
     const capability = capabilities[mediaType];
     const urls = normalizedUrls(
+      model,
       params,
       capability,
       config.singularParam,

--- a/packages/studio/src/modelFamilies.js
+++ b/packages/studio/src/modelFamilies.js
@@ -6,6 +6,11 @@ import {
   v2vModels,
 } from "./models.js";
 import { getModelMediaCapabilities } from "./modelCapabilities.js";
+import {
+  getSeedanceConfiguration,
+  resolveSeedanceVariant,
+  SEEDANCE_FAMILY_NAMES,
+} from "./seedanceModels.js";
 
 const IMAGE_FAMILY_ALIASES = {
   "bytedance-seededit-v3": "bytedance-seedream-v3",
@@ -769,5 +774,67 @@ export const imageModelPickerEntryByVariantId = indexModelPickerEntries(
 
 export const videoModelPickerEntryByVariantId = indexModelPickerEntries(
   videoModelPickerEntries,
+  videoModelCatalog,
+);
+
+function buildVideoModelMenuEntries() {
+  const entries = [];
+  const groupedFamilies = new Set();
+  const variantIdsByFamily = new Map();
+  for (const variantId of videoModelCatalog.variantById.keys()) {
+    const config = getSeedanceConfiguration(variantId);
+    if (!config) continue;
+    let variantIds = variantIdsByFamily.get(config.familyId);
+    if (!variantIds) {
+      variantIds = new Set();
+      variantIdsByFamily.set(config.familyId, variantIds);
+    }
+    variantIds.add(variantId);
+  }
+  for (const entry of videoModelPickerEntries) {
+    const config = getSeedanceConfiguration(entry.defaultVariant?.model.id);
+    if (!config) {
+      entries.push(entry);
+      continue;
+    }
+    if (groupedFamilies.has(config.familyId)) continue;
+    groupedFamilies.add(config.familyId);
+    const family = entry.family;
+    const variantIds = variantIdsByFamily.get(config.familyId);
+    const variantsByMode = {};
+    for (const [mode, workflowIds] of Object.entries({
+      t2v: [null],
+      i2v: ["animate_image", "keyframes", "references"],
+      v2v: ["edit_video", "extend_uploaded_video"],
+    })) {
+      for (const workflowId of workflowIds) {
+        const variantId = resolveSeedanceVariant({ familyId: config.familyId, workflowId });
+        const variant = videoModelCatalog.variantById.get(variantId);
+        if (variant?.mode === mode) {
+          variantsByMode[mode] = variant;
+          break;
+        }
+      }
+    }
+    const name = SEEDANCE_FAMILY_NAMES[config.familyId];
+    entries.push(Object.freeze({
+      id: `${config.familyId}:grouped`,
+      family,
+      name,
+      groupedSeedance: true,
+      variantIds,
+      variantsByMode,
+      defaultVariant: variantsByMode.t2v || variantsByMode.i2v || variantsByMode.v2v,
+      searchText: `${family.searchText} ${name}`.toLowerCase(),
+    }));
+  }
+  return Object.freeze(entries);
+}
+
+// Menu grouping is presentation-only. The original picker entries still
+// describe compatible technical variants for existing workflow resolution.
+export const videoModelMenuEntries = buildVideoModelMenuEntries();
+export const videoModelMenuEntryByVariantId = indexModelPickerEntries(
+  videoModelMenuEntries,
   videoModelCatalog,
 );

--- a/packages/studio/src/modelParameters.js
+++ b/packages/studio/src/modelParameters.js
@@ -60,6 +60,7 @@ function normalizeValue(value, schema, { includeEmpty = false } = {}) {
   }
   if (schema.type === "boolean") return typeof value === "boolean" ? value : !!schema.default;
   if (["number", "integer", "int"].includes(schema.type)) {
+    if (value === "" || value == null) return includeEmpty ? "" : undefined;
     return clampNumber(value, schema);
   }
   if (schema.type === "array") {

--- a/packages/studio/src/models.js
+++ b/packages/studio/src/models.js
@@ -7,6 +7,32 @@ import {
   T2I_DIMENSION_RATIOS,
 } from './imageSizing.js';
 
+// Verified against https://api.muapi.ai/openapi.json on 2026-09-09.
+// Seedance 2.5 uses the same inputs across its Standard, Intl and Spicy routes.
+const SEEDANCE_25_ASPECT_RATIO_INPUT = Object.freeze({
+  enum: Object.freeze(["adaptive", "16:9", "9:16", "1:1", "4:3", "3:4", "21:9", "9:21"]),
+  type: "string",
+  title: "Aspect Ratio",
+  name: "aspect_ratio",
+  description: "Aspect ratio of the output video.",
+  default: "16:9",
+});
+const SEEDANCE_HIGH_BITRATE_INPUT = Object.freeze({
+  type: "boolean",
+  title: "High Bitrate",
+  name: "high_bitrate",
+  description: "Enable high bitrate mode for better visual fidelity. Produces larger files.",
+  default: false,
+});
+const SEEDANCE_25_SEED_INPUT = Object.freeze({
+  type: "int",
+  title: "Seed",
+  name: "seed",
+  description: "Random seed for reproducible generation. Use -1 for random.",
+  minValue: -1,
+  maxValue: 4294967295,
+});
+
 export const t2iModels = [
   {
     "id": "nano-banana",
@@ -6224,7 +6250,8 @@ export const t2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -6267,7 +6294,8 @@ export const t2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -6534,7 +6562,8 @@ export const t2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -6577,7 +6606,8 @@ export const t2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -7455,23 +7485,7 @@ export const t2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -7518,23 +7532,7 @@ export const t2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -7858,7 +7856,8 @@ export const t2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -7877,35 +7876,7 @@ export const t2vModels = [
         "title": "Prompt",
         "name": "prompt"
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "3:4",
-          "4:3",
-          "21:9"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
-      "resolution": {
-        "enum": [
-          "480p",
-          "720p",
-          "1080p",
-          "4K"
-        ],
-        "title": "Resolution",
-        "name": "resolution",
-        "type": "string",
-        "description": "Output video resolution.",
-        "default": "1080p"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "duration": {
         "title": "Duration",
         "name": "duration",
@@ -7913,22 +7884,8 @@ export const t2vModels = [
         "description": "The duration of the generated video in seconds.",
         "default": 5,
         "minValue": 4,
-        "maxValue": 16,
+        "maxValue": 30,
         "step": 1
-      },
-      "generate_audio": {
-        "type": "boolean",
-        "title": "Generate Audio",
-        "name": "generate_audio",
-        "description": "Whether to generate audio for the video.",
-        "default": true
-      },
-      "camera_fixed": {
-        "type": "boolean",
-        "title": "Camera Fixed",
-        "name": "camera_fixed",
-        "description": "Whether to fix the camera position.",
-        "default": false
       },
       "high_bitrate": {
         "type": "boolean",
@@ -7936,7 +7893,8 @@ export const t2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "seed": SEEDANCE_25_SEED_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -8418,23 +8376,7 @@ export const t2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -8481,23 +8423,7 @@ export const t2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -8544,23 +8470,7 @@ export const t2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -8607,23 +8517,7 @@ export const t2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -8670,23 +8564,7 @@ export const t2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -8733,23 +8611,7 @@ export const t2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -8796,23 +8658,7 @@ export const t2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -8859,23 +8705,7 @@ export const t2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -8922,23 +8752,7 @@ export const t2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -17096,7 +16910,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -17157,7 +16972,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -17219,7 +17035,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -17283,7 +17100,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -17790,7 +17608,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -17875,7 +17694,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -18111,7 +17931,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -18172,7 +17993,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -18257,7 +18079,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -18342,7 +18165,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -18404,7 +18228,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -19373,7 +19198,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-image-to-video",
     "family": "seedance-2.5",
     "imageField": "image_url",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -19423,7 +19247,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -19829,7 +19654,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -19891,7 +19717,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -19976,7 +19803,8 @@ export const i2vModels = [
         "minValue": 4,
         "maxValue": 15,
         "step": 1
-      }
+      },
+      "high_bitrate": SEEDANCE_HIGH_BITRATE_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -19988,7 +19816,6 @@ export const i2vModels = [
     "family": "seedance-2.5",
     "imageField": "image_url",
     "lastImageField": "last_image",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -20011,29 +19838,6 @@ export const i2vModels = [
         "title": "Image URL",
         "name": "image_url"
       },
-      "last_image": {
-        "examples": [
-          null
-        ],
-        "description": "Optional URL of the last frame image for first-last frame control.",
-        "field": "image",
-        "type": "string",
-        "title": "Last Image",
-        "name": "last_image"
-      },
-      "resolution": {
-        "enum": [
-          "480p",
-          "720p",
-          "1080p",
-          "4K"
-        ],
-        "title": "Resolution",
-        "name": "resolution",
-        "type": "string",
-        "description": "Output video resolution.",
-        "default": "1080p"
-      },
       "duration": {
         "title": "Duration",
         "name": "duration",
@@ -20041,22 +19845,8 @@ export const i2vModels = [
         "description": "The duration of the generated video in seconds.",
         "default": 5,
         "minValue": 4,
-        "maxValue": 16,
+        "maxValue": 30,
         "step": 1
-      },
-      "generate_audio": {
-        "type": "boolean",
-        "title": "Generate Audio",
-        "name": "generate_audio",
-        "description": "Whether to generate audio for the video.",
-        "default": true
-      },
-      "camera_fixed": {
-        "type": "boolean",
-        "title": "Camera Fixed",
-        "name": "camera_fixed",
-        "description": "Whether to fix the camera position.",
-        "default": false
       },
       "high_bitrate": {
         "type": "boolean",
@@ -20064,7 +19854,9 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
+      "seed": SEEDANCE_25_SEED_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -20075,7 +19867,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-image-to-video-480p",
     "family": "seedance-2.5",
     "imageField": "image_url",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -20125,7 +19916,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -20136,7 +19928,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-first-last-frame",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -20191,7 +19982,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -20202,7 +19994,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-first-last-frame-480p",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -20257,7 +20048,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -20327,23 +20119,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -20444,23 +20220,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -21208,7 +20968,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-image-to-video-1080p",
     "family": "seedance-2.5",
     "imageField": "image_url",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -21258,7 +21017,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -21269,7 +21029,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-image-to-video-4k",
     "family": "seedance-2.5",
     "imageField": "image_url",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -21319,7 +21078,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -21330,7 +21090,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-first-last-frame-1080p",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -21385,7 +21144,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -21396,7 +21156,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-first-last-frame-4k",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -21451,7 +21210,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -21521,23 +21281,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -21638,23 +21382,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -21696,7 +21424,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-intl-image-to-video",
     "family": "seedance-2.5",
     "imageField": "image_url",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -21746,7 +21473,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -21757,7 +21485,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-intl-image-to-video-480p",
     "family": "seedance-2.5",
     "imageField": "image_url",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -21807,7 +21534,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -21818,7 +21546,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-spicy-image-to-video-480p",
     "family": "seedance-2.5",
     "imageField": "image_url",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -21868,7 +21595,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -21879,7 +21607,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-intl-image-to-video-1080p",
     "family": "seedance-2.5",
     "imageField": "image_url",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -21929,7 +21656,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -21940,7 +21668,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-spicy-image-to-video-1080p",
     "family": "seedance-2.5",
     "imageField": "image_url",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -21990,7 +21717,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -22001,7 +21729,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-intl-image-to-video-4k",
     "family": "seedance-2.5",
     "imageField": "image_url",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -22051,7 +21778,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -22062,7 +21790,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-spicy-image-to-video-4k",
     "family": "seedance-2.5",
     "imageField": "image_url",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -22112,7 +21839,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -22123,7 +21851,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-intl-first-last-frame",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -22178,7 +21905,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -22189,7 +21917,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-spicy-first-last-frame",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -22244,7 +21971,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -22255,7 +21983,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-intl-first-last-frame-480p",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -22310,7 +22037,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -22321,7 +22049,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-spicy-first-last-frame-480p",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -22376,7 +22103,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -22387,7 +22115,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-intl-first-last-frame-1080p",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -22442,7 +22169,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -22453,7 +22181,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-spicy-first-last-frame-1080p",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -22508,7 +22235,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -22519,7 +22247,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-intl-first-last-frame-4k",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -22574,7 +22301,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -22585,7 +22313,6 @@ export const i2vModels = [
     "endpoint": "seedance-2.5-spicy-first-last-frame-4k",
     "family": "seedance-2.5",
     "imageField": "images_list",
-    "aspectRatioMode": "inherited",
     "hasPrompt": true,
     "promptRequired": true,
     "inputs": {
@@ -22640,7 +22367,8 @@ export const i2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "provider": "bytedance",
     "provider_name": "ByteDance"
@@ -22710,23 +22438,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -22827,23 +22539,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -22944,23 +22640,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -23061,23 +22741,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -23178,23 +22842,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -23295,23 +22943,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -23412,23 +23044,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -23529,23 +23145,7 @@ export const i2vModels = [
         "maxValue": 30,
         "step": 1
       },
-      "aspect_ratio": {
-        "enum": [
-          "adaptive",
-          "16:9",
-          "9:16",
-          "1:1",
-          "4:3",
-          "3:4",
-          "21:9",
-          "9:21"
-        ],
-        "title": "Aspect Ratio",
-        "name": "aspect_ratio",
-        "type": "string",
-        "description": "Aspect ratio of the output video.",
-        "default": "16:9"
-      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT,
       "seed": {
         "type": "int",
         "title": "Seed",
@@ -25719,7 +25319,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed.",
     "provider": "bytedance",
@@ -25821,7 +25422,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit 480p edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed.",
     "provider": "bytedance",
@@ -25923,7 +25525,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit 1080p edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed.",
     "provider": "bytedance",
@@ -26025,7 +25628,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit 4K edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed.",
     "provider": "bytedance",
@@ -26109,7 +25713,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt.",
     "provider": "bytedance",
@@ -26193,7 +25798,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend 480p extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt.",
     "provider": "bytedance",
@@ -26277,7 +25883,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend 1080p extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt.",
     "provider": "bytedance",
@@ -26361,7 +25968,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend 4K extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt.",
     "provider": "bytedance",
@@ -26463,7 +26071,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed. This international-region endpoint is served via a Dreamina-hosted deployment of the same Seedance 2.5 model, for traffic outside mainland China.",
     "provider": "bytedance",
@@ -26565,7 +26174,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed. This Spicy endpoint is the relaxed-moderation sibling of the standard tier, with lighter content-safety filtering and bolder, higher-contrast output.",
     "provider": "bytedance",
@@ -26667,7 +26277,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit 480p edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed. This international-region endpoint is served via a Dreamina-hosted deployment of the same Seedance 2.5 model, for traffic outside mainland China.",
     "provider": "bytedance",
@@ -26769,7 +26380,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit 480p edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed. This Spicy endpoint is the relaxed-moderation sibling of the standard tier, with lighter content-safety filtering and bolder, higher-contrast output.",
     "provider": "bytedance",
@@ -26871,7 +26483,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit 1080p edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed. This international-region endpoint is served via a Dreamina-hosted deployment of the same Seedance 2.5 model, for traffic outside mainland China.",
     "provider": "bytedance",
@@ -26973,7 +26586,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit 1080p edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed. This Spicy endpoint is the relaxed-moderation sibling of the standard tier, with lighter content-safety filtering and bolder, higher-contrast output.",
     "provider": "bytedance",
@@ -27075,7 +26689,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit 4K edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed. This international-region endpoint is served via a Dreamina-hosted deployment of the same Seedance 2.5 model, for traffic outside mainland China.",
     "provider": "bytedance",
@@ -27177,7 +26792,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Edit 4K edits an input video from a natural-language prompt. The reference video drives subject identity, composition, and motion while the model rewrites lighting, style, weather, environment, or specific elements as instructed. This Spicy endpoint is the relaxed-moderation sibling of the standard tier, with lighter content-safety filtering and bolder, higher-contrast output.",
     "provider": "bytedance",
@@ -27261,7 +26877,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt. This international-region endpoint is served via a Dreamina-hosted deployment of the same Seedance 2.5 model, for traffic outside mainland China.",
     "provider": "bytedance",
@@ -27345,7 +26962,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt. This Spicy endpoint is the relaxed-moderation sibling of the standard tier, with lighter content-safety filtering and bolder, higher-contrast output.",
     "provider": "bytedance",
@@ -27429,7 +27047,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend 480p extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt. This international-region endpoint is served via a Dreamina-hosted deployment of the same Seedance 2.5 model, for traffic outside mainland China.",
     "provider": "bytedance",
@@ -27513,7 +27132,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend 480p extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt. This Spicy endpoint is the relaxed-moderation sibling of the standard tier, with lighter content-safety filtering and bolder, higher-contrast output.",
     "provider": "bytedance",
@@ -27597,7 +27217,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend 1080p extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt. This international-region endpoint is served via a Dreamina-hosted deployment of the same Seedance 2.5 model, for traffic outside mainland China.",
     "provider": "bytedance",
@@ -27681,7 +27302,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend 1080p extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt. This Spicy endpoint is the relaxed-moderation sibling of the standard tier, with lighter content-safety filtering and bolder, higher-contrast output.",
     "provider": "bytedance",
@@ -27765,7 +27387,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend 4K extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt. This international-region endpoint is served via a Dreamina-hosted deployment of the same Seedance 2.5 model, for traffic outside mainland China.",
     "provider": "bytedance",
@@ -27849,7 +27472,8 @@ export const v2vModels = [
         "name": "high_bitrate",
         "description": "Enable high bitrate mode for better visual fidelity. Produces larger files.",
         "default": false
-      }
+      },
+      "aspect_ratio": SEEDANCE_25_ASPECT_RATIO_INPUT
     },
     "description": "Seedance 2.5 Video Extend 4K extends an input video with a new cinematic continuation generated from its last frame and a natural-language prompt. This Spicy endpoint is the relaxed-moderation sibling of the standard tier, with lighter content-safety filtering and bolder, higher-contrast output.",
     "provider": "bytedance",

--- a/packages/studio/src/muapi.js
+++ b/packages/studio/src/muapi.js
@@ -6,8 +6,9 @@ import {
 import { buildImageSizePayload } from './imageSizing.js';
 import { buildImageInputPayload, getImageInputValidationError, normalizePrimaryImageUrls } from './imageInputContracts.js';
 import { pollForGenerationResult } from './utils/generationLifecycle.js';
-import { mapReferenceParams } from './modelCapabilities.js';
+import { getModelMediaCapabilities, mapReferenceParams } from './modelCapabilities.js';
 import { buildSupplementalInputPayload } from './modelParameters.js';
+import { getSeedanceConfiguration } from './seedanceModels.js';
 
 // In an http(s) browser we route through the host app's proxy (Next.js routes
 // under /api/* re-issue the call server-side) so api.muapi.ai CORS is bypassed.
@@ -151,6 +152,7 @@ export async function decomposeLayers(apiKey, params) {
 export async function generateVideo(apiKey, params) {
     const modelInfo = getVideoModelById(params.model);
     const endpoint = modelInfo?.endpoint || params.model;
+    const mediaCapabilities = getModelMediaCapabilities(modelInfo);
     assertRequiredPrompt(modelInfo, params);
     let payload = {
         ...mapReferenceParams(modelInfo, params),
@@ -163,10 +165,10 @@ export async function generateVideo(apiKey, params) {
     if (params.resolution) payload.resolution = params.resolution;
     if (params.quality) payload.quality = params.quality;
     if (params.mode) payload.mode = params.mode;
-    if (params.image_url) payload.image_url = params.image_url;
-    if (params.images_list?.length > 0) payload.images_list = params.images_list;
-    if (params.videos_list?.length > 0) payload.videos_list = params.videos_list;
-    if (params.video_files?.length > 0) payload.video_files = params.video_files;
+    if (!mediaCapabilities.image.field && params.image_url) payload.image_url = params.image_url;
+    if (!mediaCapabilities.image.field && params.images_list?.length > 0) payload.images_list = params.images_list;
+    if (!mediaCapabilities.video.field && params.videos_list?.length > 0) payload.videos_list = params.videos_list;
+    if (!mediaCapabilities.video.field && params.video_files?.length > 0) payload.video_files = params.video_files;
     Object.assign(payload, serializeVideoToolOptions(modelInfo, params.options));
     payload = includeRequiredArrayDefaults(modelInfo, payload);
     return submitAndPoll(endpoint, payload, apiKey, params.onRequestId, 900);
@@ -210,12 +212,19 @@ export async function processV2V(apiKey, params) {
     const endpoint = modelInfo?.endpoint || params.model;
     const toolPayload = buildVideoToolPayload(modelInfo, params);
     let payload = {
-        ...mapReferenceParams(modelInfo, params),
         ...buildSupplementalInputPayload(modelInfo, params),
         ...toolPayload,
+        ...mapReferenceParams(modelInfo, params),
     };
     if (modelInfo?.hasPrompt && params.prompt) {
         payload.prompt = params.prompt;
+    }
+    if (getSeedanceConfiguration(modelInfo?.id)) {
+        for (const field of ['duration', 'aspect_ratio', 'resolution', 'quality']) {
+            if (modelInfo.inputs?.[field] && params[field] !== undefined) {
+                payload[field] = params[field];
+            }
+        }
     }
     payload = includeRequiredArrayDefaults(modelInfo, payload);
     return submitAndPoll(endpoint, payload, apiKey, params.onRequestId, 900);

--- a/packages/studio/src/seedanceCopy.js
+++ b/packages/studio/src/seedanceCopy.js
@@ -1,0 +1,11 @@
+import { getVideoWorkflowMediaSlots } from "./videoWorkflows.js";
+
+export function getSeedanceModeDescription(model, workflowId, copy) {
+  const description = copy.modeDescriptions[workflowId || "text"];
+  if (workflowId !== "references" || !model) return description;
+
+  const media = getVideoWorkflowMediaSlots(model, workflowId)
+    .map((slot) => copy.referenceMediaTypes[slot.mediaType])
+    .join(" · ");
+  return `${description} ${copy.referenceSupport.replace("{media}", media)}`;
+}

--- a/packages/studio/src/seedanceModels.js
+++ b/packages/studio/src/seedanceModels.js
@@ -1,0 +1,296 @@
+import { i2vModels, t2vModels, v2vModels } from "./models.js";
+
+// Endpoint coordinates are separate from ordinary generation parameters. In
+// particular, an unsuffixed endpoint does not promise a specific resolution.
+const FACETS = Object.freeze(["profile", "speed", "resolution"]);
+const modelIds = new Set(
+  [...t2vModels, ...i2vModels, ...v2vModels].map((model) => model.id),
+);
+const configurations = new Map();
+
+export const SEEDANCE_FAMILY_NAMES = Object.freeze({
+  "seedance-2.5": "Seedance 2.5",
+  "seedance-2": "Seedance 2.0",
+  "seedance-1.5": "Seedance 1.5 Pro",
+  "seedance-pro": "Seedance 1.0 Pro",
+  "seedance-lite": "Seedance 1.0 Lite",
+});
+
+const PROFILE_OPTIONS = Object.freeze([
+  { value: "standard", label: "Standard" },
+  { value: "intl", label: "International" },
+  { value: "vip", label: "VIP" },
+  { value: "mini", label: "Mini" },
+  { value: "spicy", label: "Spicy" },
+  { value: "mini_spicy", label: "Mini Spicy" },
+  { value: "legacy", label: "Original" },
+  { value: "legacy_new", label: "Original updated" },
+]);
+const FACET_OPTIONS = Object.freeze({
+  profile: PROFILE_OPTIONS,
+  speed: [
+    { value: "standard", label: "Standard" },
+    { value: "fast", label: "Fast" },
+  ],
+  resolution: [
+    { value: "default", label: "Automatic", description: "Uses the model variant’s default resolution." },
+    { value: "480p", label: "480p" },
+    { value: "1080p", label: "1080p" },
+    { value: "4k", label: "4K" },
+  ],
+});
+
+function register(modelId, familyId, workflowIds, facets = {}) {
+  // The service matrix is explicit, but not every version offers every cell.
+  // Only endpoints present in the local provider catalog become selectable.
+  if (!modelIds.has(modelId)) return;
+  configurations.set(modelId, Object.freeze({
+    familyId,
+    profile: "standard",
+    speed: "standard",
+    resolution: "default",
+    ...facets,
+    workflowIds: Object.freeze(workflowIds),
+  }));
+}
+
+const MODERN_WORKFLOWS = Object.freeze({
+  text: { stem: "text-to-video", workflowId: null },
+  image: { stem: "image-to-video", workflowId: "animate_image" },
+  keyframes: { stem: "first-last-frame", workflowId: "keyframes" },
+  references: { stem: "omni-reference", workflowId: "references" },
+  edit: { stem: "video-edit", workflowId: "edit_video" },
+  extend: { stem: "video-extend", workflowId: "extend_uploaded_video" },
+});
+
+for (const profile of ["standard", "intl", "spicy"]) {
+  for (const { stem, workflowId } of Object.values(MODERN_WORKFLOWS)) {
+    for (const resolution of ["default", "480p", "1080p", "4k"]) {
+      register(
+        `seedance-2.5-${profile === "standard" ? "" : `${profile}-`}${stem}${resolution === "default" ? "" : `-${resolution}`}`,
+        "seedance-2.5",
+        [workflowId],
+        { profile, resolution },
+      );
+    }
+  }
+}
+
+for (const profile of ["standard", "vip", "mini", "spicy", "mini_spicy"]) {
+  const prefix = profile === "standard" ? "" : `${profile.replace("_", "-")}-`;
+  const modes = profile === "standard" || profile === "vip"
+    ? ["text", "image", "keyframes", "references"]
+    : profile === "mini" ? ["text", "image", "references"] : ["text", "image"];
+  for (const mode of modes) {
+    const { stem, workflowId } = MODERN_WORKFLOWS[mode];
+    const endpointStem = profile === "standard" && mode === "references"
+      ? "omni-reference-no-video"
+      : stem;
+    for (const speed of ["standard", "fast"]) {
+      for (const resolution of ["default", "1080p", "4k"]) {
+        register(
+          `seedance-2-${prefix}${endpointStem}${speed === "fast" ? "-fast" : ""}${resolution === "default" ? "" : `-${resolution}`}`,
+          "seedance-2",
+          [workflowId],
+          { profile, speed, resolution },
+        );
+      }
+    }
+  }
+}
+
+for (const [stem, workflowId] of [
+  ["t2v", null],
+  ["i2v", "animate_image"],
+  ["omni-reference", "references"],
+]) {
+  for (const resolution of ["default", "480p"]) {
+    register(
+      `seedance-2-${stem}${resolution === "default" ? "" : `-${resolution}`}`,
+      "seedance-2",
+      [workflowId],
+      { profile: "legacy", resolution },
+    );
+  }
+  // Historical IDs are persisted in projects. They are aliases of the same
+  // endpoint, not additional service choices.
+  if (stem !== "omni-reference") {
+    register(`seedance-v2.0-${stem}`, "seedance-2", [workflowId], { profile: "legacy" });
+  }
+}
+for (const [stem, workflowId] of [
+  ["t2v", null],
+  ["first-last", "keyframes"],
+  ["omni", "references"],
+]) {
+  register(`seedance-2-new-${stem}`, "seedance-2", [workflowId], { profile: "legacy_new" });
+}
+
+for (const [familyId, prefix] of [
+  ["seedance-1.5", "seedance-v1.5-pro"],
+  ["seedance-pro", "seedance-pro"],
+  ["seedance-lite", "seedance-lite"],
+]) {
+  for (const speed of ["standard", "fast"]) {
+    const suffix = speed === "fast" ? "-fast" : "";
+    register(`${prefix}-t2v${suffix}`, familyId, [null], { speed });
+    // Only Lite and 1.5 expose an end-frame input in this catalog.
+    register(`${prefix}-i2v${suffix}`, familyId,
+      familyId === "seedance-pro" ? ["animate_image"] : ["animate_image", "keyframes"],
+      { speed });
+    register(`${prefix}-video-extend${suffix}`, familyId, ["extend_uploaded_video"], { speed });
+  }
+}
+register("seedance-lite-reference-video", "seedance-lite", ["references"]);
+
+export function getSeedanceConfiguration(modelId) {
+  return configurations.get(modelId) || null;
+}
+
+// MuAPI's family tables specify 720p for these unsuffixed services:
+// https://muapi.ai/seedance-2.5 and https://muapi.ai/seedance-2 (2026-09-09).
+// Older API routes with no documented size deliberately remain unspecified.
+export function getSeedanceEndpointResolution(modelId) {
+  const config = getSeedanceConfiguration(modelId);
+  if (!config) return undefined;
+  if (config.resolution !== "default") return config.resolution;
+  if (config.familyId === "seedance-2.5" ||
+      (config.familyId === "seedance-2" && ["standard", "vip", "spicy"].includes(config.profile))) return "720p";
+  return undefined;
+}
+
+// These operations consume a previous result or an uploaded video; they are
+// separate from the generation variants in the model-version picker.
+const seedanceTools = new Map([
+  ["seedance-2-extend", { group: "continueGenerated", variant: "standard", order: 0 }],
+  ["seedance-v2.0-extend", { group: "continueGenerated", variant: "standard", order: 0 }],
+  ["seedance-2-vip-extend", { group: "continueGenerated", variant: "vip", order: 1 }],
+  ["seedance-2-vip-extend-1080p", { group: "continueGenerated", variant: "vip", resolution: "1080p", order: 2 }],
+  ["seedance-2-watermark-remover", { group: "removeWatermark", variant: "standard", order: 0 }],
+  ["seedance-2-video-watermark-remover-pro", { group: "removeWatermark", variant: "pro", order: 1 }],
+]);
+
+export function getSeedanceToolConfiguration(modelId) {
+  return seedanceTools.get(modelId);
+}
+
+function coordinateKey({ profile, speed, resolution }) {
+  return `${profile}\u0000${speed}\u0000${resolution}`;
+}
+
+const FACET_LABELS = Object.freeze({
+  profile: "Model variant", speed: "Speed", resolution: "Resolution",
+});
+const EMPTY_OPTIONS = Object.freeze([]);
+const profilePriority = new Map(PROFILE_OPTIONS.map((option, index) => [option.value, index]));
+
+function defaultScore(config) {
+  return profilePriority.get(config.profile) * 100 +
+    (config.speed === "standard" ? 0 : 10) +
+    (config.resolution === "default" ? 0 : 1);
+}
+
+function buildSelectionIndex() {
+  const families = new Map();
+  for (const [modelId, config] of configurations) {
+    let family = families.get(config.familyId);
+    if (!family) {
+      family = { workflows: new Map(), coordinates: new Map() };
+      families.set(config.familyId, family);
+    }
+    const key = coordinateKey(config);
+    family.coordinates.set(key, config);
+    const score = defaultScore(config);
+    for (const workflowId of config.workflowIds) {
+      let group = family.workflows.get(workflowId);
+      if (!group) {
+        group = {
+          modelIds: [],
+          variantByCoordinates: new Map(),
+          optionsByCoordinates: new Map(),
+          facetValues: Object.fromEntries(FACETS.map((facet) => [facet, new Set()])),
+          defaultConfiguration: config,
+          defaultScore: score,
+        };
+        family.workflows.set(workflowId, group);
+      }
+      group.modelIds.push(modelId);
+      const existingId = group.variantByCoordinates.get(key);
+      // Historical v2.0 IDs share an endpoint with the current catalog IDs.
+      if (!existingId || existingId.startsWith("seedance-v2.0-")) {
+        group.variantByCoordinates.set(key, modelId);
+      }
+      if (score < group.defaultScore) {
+        group.defaultConfiguration = config;
+        group.defaultScore = score;
+      }
+      for (const facet of FACETS) group.facetValues[facet].add(config[facet]);
+    }
+  }
+
+  // Workflows (at most six) and facet values are bounded by the explicit
+  // matrices above. Precompute each choice once; rendering only looks it up.
+  for (const family of families.values()) {
+    for (const group of family.workflows.values()) {
+      const fields = FACETS.flatMap((key) => group.facetValues[key].size > 1 ? [{
+        key,
+        label: FACET_LABELS[key],
+        options: FACET_OPTIONS[key].filter((option) => group.facetValues[key].has(option.value)),
+      }] : []);
+      for (const [coordinates, config] of family.coordinates) {
+        const options = fields.map((field) => Object.freeze({
+          key: field.key,
+          label: field.label,
+          value: config[field.key],
+          options: Object.freeze(field.options.map((option) => Object.freeze({
+            ...option,
+            disabled: !group.variantByCoordinates.has(coordinateKey({
+              ...config, [field.key]: option.value,
+            })),
+          }))),
+        }));
+        group.optionsByCoordinates.set(coordinates, Object.freeze(options));
+      }
+      delete group.facetValues;
+      delete group.defaultScore;
+    }
+  }
+  return families;
+}
+
+const selectionIndex = buildSelectionIndex();
+
+export const SEEDANCE_WORKFLOW_VARIANTS = Object.freeze(Object.fromEntries(
+  [...selectionIndex].map(([familyId, family]) => [familyId, Object.freeze(Object.fromEntries(
+    [...family.workflows]
+      .filter(([workflowId]) => workflowId !== null)
+      .map(([workflowId, group]) => [workflowId, Object.freeze(group.modelIds)]),
+  ))]),
+));
+
+export function resolveSeedanceVariant({
+  familyId,
+  workflowId = null,
+  currentModelId = null,
+  changes = {},
+}) {
+  if (Object.keys(changes).some((key) => !FACETS.includes(key))) return null;
+  const group = selectionIndex.get(familyId)?.workflows.get(workflowId);
+  if (!group) return null;
+  const current = getSeedanceConfiguration(currentModelId);
+  const coordinates = current?.familyId === familyId
+    ? current
+    : group.defaultConfiguration;
+  const requestedKey = coordinateKey({ ...coordinates, ...changes });
+  if (current?.familyId === familyId && current.workflowIds.includes(workflowId) &&
+      coordinateKey(current) === requestedKey) return currentModelId;
+  return group.variantByCoordinates.get(requestedKey) || null;
+}
+
+export function getSeedanceVariantOptions(familyId, workflowId = null, currentModelId = null) {
+  const group = selectionIndex.get(familyId)?.workflows.get(workflowId);
+  if (!group) return EMPTY_OPTIONS;
+  const current = getSeedanceConfiguration(currentModelId);
+  const selected = current?.familyId === familyId ? current : group.defaultConfiguration;
+  return group.optionsByCoordinates.get(coordinateKey(selected));
+}

--- a/packages/studio/src/seedanceParameters.js
+++ b/packages/studio/src/seedanceParameters.js
@@ -1,0 +1,364 @@
+import { videoModelCatalog } from "./modelFamilies.js";
+import {
+  getSeedanceConfiguration,
+  getSeedanceEndpointResolution,
+  getSeedanceVariantOptions,
+  resolveSeedanceVariant,
+} from "./seedanceModels.js";
+
+const COMMON_FIELDS = Object.freeze([
+  ["aspectRatio", "aspect_ratio", "aspectRatios"],
+  ["duration", "duration", "durations"],
+  ["resolution", "resolution", "resolutions"],
+  ["quality", "quality", "qualities"],
+]);
+
+function schemaOptions(schema) {
+  if (!schema) return [];
+  if (Array.isArray(schema.enum)) return [...schema.enum];
+  const minimum = schema.minValue ?? schema.minimum;
+  const maximum = schema.maxValue ?? schema.maximum;
+  const step = schema.step ?? (["int", "integer"].includes(schema.type) ? 1 : undefined);
+  if (
+    Number.isFinite(minimum) && Number.isFinite(maximum) &&
+    Number.isFinite(step) && step > 0 && maximum >= minimum
+  ) {
+    const count = Math.floor((maximum - minimum) / step + 1e-9) + 1;
+    // Common controls are small selects. Do not materialize an unbounded or
+    // unexpectedly large range from a future provider schema.
+    if (count > 1000) return [];
+    return Array.from({ length: count }, (_, index) =>
+      Number((minimum + index * step).toFixed(10)));
+  }
+  return schema.default === undefined ? [] : [schema.default];
+}
+
+function matchingValue(options, value) {
+  if (value === undefined || value === null || value === "") return undefined;
+  return options.find((option) => option === value || String(option) === String(value));
+}
+
+function nearestDuration(options, value) {
+  if (value === undefined || value === null || value === "" || !Number.isFinite(Number(value))) return undefined;
+  let nearest;
+  for (const option of options) {
+    if (Number.isFinite(Number(option)) &&
+        (nearest === undefined || Math.abs(Number(option) - Number(value)) < Math.abs(Number(nearest) - Number(value)))) {
+      nearest = option;
+    }
+  }
+  return nearest;
+}
+
+export function getSeedanceCommonOptions(model) {
+  return Object.fromEntries(COMMON_FIELDS.map(([, field, key]) =>
+    [key, field === "aspect_ratio" && model?.aspectRatioMode === "inherited"
+      ? []
+      : schemaOptions(model?.inputs?.[field])]));
+}
+
+export function getSeedanceCommonValues(model, previous = {}) {
+  const options = getSeedanceCommonOptions(model);
+  return Object.fromEntries(COMMON_FIELDS.map(([key, field, optionsKey]) => {
+    const allowed = options[optionsKey];
+    const value = matchingValue(allowed, previous[key]) ??
+      (key === "duration" ? nearestDuration(allowed, previous[key]) : undefined) ??
+      matchingValue(allowed, model?.inputs?.[field]?.default) ?? allowed[0];
+    return [key, value];
+  }));
+}
+
+export function buildSeedanceCommonPayload(model, values = {}) {
+  const options = getSeedanceCommonOptions(model);
+  return Object.fromEntries(COMMON_FIELDS.flatMap(([key, field, optionsKey]) => {
+    const value = matchingValue(options[optionsKey], values[key]);
+    return value === undefined ? [] : [[field, value]];
+  }));
+}
+
+function resolutionLabel(value) {
+  return String(value).toLowerCase() === "4k" ? "4K" : String(value);
+}
+
+function modelForId(modelId) {
+  return videoModelCatalog.variantById.get(modelId)?.model;
+}
+
+function followsSourceVideoResolution(modelId) {
+  const config = getSeedanceConfiguration(modelId);
+  if (config.resolution !== "default" || !config.workflowIds.includes("extend_uploaded_video") ||
+    getSeedanceCommonOptions(modelForId(modelId)).resolutions.length) return false;
+  return !getSeedanceVariantOptions(config.familyId, "extend_uploaded_video", modelId)
+    .some((field) => field.key === "resolution" && field.options.some((option) =>
+      !option.disabled && option.value !== "default"));
+}
+
+// Index actual catalog models once. A plan scans only the requested family's
+// mode, whose native resolution and common-parameter ranges are bounded.
+const selectionCandidates = new Map();
+for (const { model } of videoModelCatalog.variantById.values()) {
+  const config = getSeedanceConfiguration(model.id);
+  if (!config) continue;
+  let workflows = selectionCandidates.get(config.familyId);
+  if (!workflows) selectionCandidates.set(config.familyId, workflows = new Map());
+  const candidate = { model, config, options: getSeedanceCommonOptions(model) };
+  for (const workflowId of config.workflowIds) {
+    let candidates = workflows.get(workflowId);
+    if (!candidates) workflows.set(workflowId, candidates = []);
+    candidates.push(candidate);
+  }
+}
+
+const RESOLUTION_SIZE = Object.freeze({ "480p": 480, "720p": 720, "1080p": 1080, "4k": 2160 });
+const normalizeResolution = (value) => value === undefined ? undefined : String(value).toLowerCase();
+
+function effectiveResolution(modelId, nativeResolution) {
+  const config = getSeedanceConfiguration(modelId);
+  if (!config) return undefined;
+  const fixed = getSeedanceEndpointResolution(modelId);
+  if (fixed !== undefined) return fixed;
+  const native = getSeedanceCommonValues(modelForId(modelId), { resolution: nativeResolution }).resolution;
+  if (native !== undefined) return normalizeResolution(native);
+  return followsSourceVideoResolution(modelId) ? undefined : "default";
+}
+
+function resolutionScore(value, preferred) {
+  if (value === preferred) return [0, 0];
+  if (preferred === undefined || preferred === "default") return [1, 0];
+  const size = RESOLUTION_SIZE[value];
+  const preferredSize = RESOLUTION_SIZE[preferred];
+  if (!size || !preferredSize) return [3, 0];
+  // Preserve detail when an exact size is unavailable. Only use a smaller
+  // output when the requested mode has no size at or above the old one.
+  return size >= preferredSize ? [1, size - preferredSize] : [2, preferredSize - size];
+}
+
+function compareScores(left, right) {
+  for (let index = 0; index < left.length; index++) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+function commonAdjustments(model, previous) {
+  const target = getSeedanceCommonValues(model, previous);
+  return ["duration", "aspectRatio", "quality"].flatMap((key) =>
+    previous[key] !== undefined && target[key] !== undefined && String(previous[key]) !== String(target[key])
+      ? [{ key, from: previous[key], to: target[key] }] : []);
+}
+
+export function getSeedanceSelectionAdjustments({
+  currentModelId,
+  nativeResolution,
+  commonValues = {},
+  selection,
+  changes = {},
+}) {
+  const current = getSeedanceConfiguration(currentModelId);
+  const target = getSeedanceConfiguration(selection.modelId);
+  if (!current || current.familyId !== target?.familyId) return [];
+  const adjustments = ["profile", "speed"].flatMap((key) =>
+    !Object.hasOwn(changes, key) && current[key] !== target[key]
+      ? [{ key, from: current[key], to: target[key] }] : []);
+  const sourceResolution = effectiveResolution(currentModelId, nativeResolution ?? commonValues.resolution);
+  const resolution = effectiveResolution(selection.modelId, selection.resolution);
+  if (!Object.hasOwn(changes, "resolution") && sourceResolution !== undefined && sourceResolution !== "default" &&
+      resolution !== undefined && sourceResolution !== resolution) {
+    adjustments.push({ key: "resolution", from: sourceResolution, to: resolution });
+  }
+  const visibleCommonValues = getSeedanceCommonValues(modelForId(currentModelId), commonValues);
+  adjustments.push(...commonAdjustments(modelForId(selection.modelId), visibleCommonValues));
+  return adjustments;
+}
+
+export function planSeedanceSelection({
+  familyId,
+  workflowId = null,
+  currentModelId,
+  changes = {},
+  nativeResolution,
+  commonValues = {},
+}) {
+  const candidates = selectionCandidates.get(familyId)?.get(workflowId);
+  if (!candidates || Object.keys(changes).some((key) => !["profile", "speed", "resolution"].includes(key))) return null;
+  const source = getSeedanceConfiguration(currentModelId);
+  const current = source?.familyId === familyId ? source : null;
+  const previous = current ? commonValues : {};
+  const sourceResolution = current ? effectiveResolution(currentModelId, nativeResolution ?? commonValues.resolution) : undefined;
+  const strict = resolveSeedanceSelection({ familyId, workflowId, currentModelId, changes,
+    nativeResolution: nativeResolution ?? commonValues.resolution });
+  const preferredResolution = current
+    ? sourceResolution === "default" && strict
+      ? effectiveResolution(strict.modelId, strict.resolution)
+      : sourceResolution ?? normalizeResolution(nativeResolution ?? commonValues.resolution)
+    : undefined;
+
+  const finish = (selection) => ({ selection, adjustments: getSeedanceSelectionAdjustments({
+    currentModelId, nativeResolution, commonValues, selection, changes,
+  }) });
+  // Keep the existing endpoint and values whenever they already satisfy the
+  // request. Unknown/family-switching sources start at the actual defaults.
+  if (strict && (!current || !commonAdjustments(modelForId(strict.modelId), previous).length)) return finish(strict);
+
+  const defaultProfile = getSeedanceConfiguration(resolveSeedanceVariant({ familyId, workflowId }))?.profile;
+  let best;
+  for (const candidate of candidates) {
+    if (Object.entries(changes).some(([key, value]) => key !== "resolution" && candidate.config[key] !== value)) continue;
+    // Undocumented older services remain explicitly selectable and restorable,
+    // but are never an automatic fallback for another service.
+    if (candidate.config.profile.startsWith("legacy") &&
+        candidate.config.profile !== current?.profile && changes.profile !== candidate.config.profile) continue;
+    const { model, config, options } = candidate;
+    let resolution = getSeedanceCommonValues(model).resolution;
+    if (Object.hasOwn(changes, "resolution")) {
+      if (changes.resolution === "default") {
+        if (config.resolution !== "default") continue;
+      } else {
+        resolution = options.resolutions.find((value) => normalizeResolution(value) === normalizeResolution(changes.resolution));
+        if (effectiveResolution(model.id, resolution) !== normalizeResolution(changes.resolution)) continue;
+      }
+    } else if (options.resolutions.length) {
+      let score = resolutionScore(normalizeResolution(resolution), preferredResolution);
+      for (const option of options.resolutions) {
+        const nextScore = resolutionScore(normalizeResolution(option), preferredResolution);
+        if (compareScores(nextScore, score) < 0) {
+          resolution = option;
+          score = nextScore;
+        }
+      }
+    }
+    const selection = { modelId: model.id, ...(resolution === undefined ? {} : { resolution }) };
+    const common = commonAdjustments(model, previous);
+    const score = [
+      config.profile === current?.profile ? 0 : config.profile === defaultProfile ? 1 : 2,
+      ...resolutionScore(effectiveResolution(model.id, resolution), preferredResolution),
+      current && config.speed !== current.speed ? 1 : 0,
+      common.length,
+      model.id === strict?.modelId || model.id === currentModelId ? 0 : 1,
+      config.profile === "standard" ? 0 : 1,
+      config.speed === "standard" ? 0 : 1,
+      config.resolution === "default" ? 0 : 1,
+    ];
+    if (!best || compareScores(score, best.score) < 0) best = { selection, score };
+  }
+  return best ? finish(best.selection) : null;
+}
+
+export function resolveSeedanceSelection({
+  familyId,
+  workflowId = null,
+  currentModelId,
+  changes = {},
+  nativeResolution,
+}) {
+  const current = getSeedanceConfiguration(currentModelId);
+  if (Object.keys(changes).some((key) => !["profile", "speed", "resolution"].includes(key))) return null;
+
+  const resolve = (resolution) => resolveSeedanceVariant({
+    familyId, workflowId, currentModelId,
+    changes: { ...changes, ...(resolution === undefined ? {} : { resolution }) },
+  });
+  const withDefaultResolution = (modelId) => {
+    if (!modelId) return null;
+    const resolution = getSeedanceCommonValues(modelForId(modelId)).resolution;
+    return { modelId, ...(resolution === undefined ? {} : { resolution }) };
+  };
+
+  const requestedResolution = changes.resolution;
+  if (requestedResolution !== undefined && requestedResolution !== "default") {
+    const size = normalizeResolution(requestedResolution);
+    for (const modelId of new Set([resolve(size), resolve("default")])) {
+      if (!modelId) continue;
+      const native = getSeedanceCommonOptions(modelForId(modelId)).resolutions
+        .find((value) => normalizeResolution(value) === size);
+      if (native !== undefined) return { modelId, resolution: native };
+      if (getSeedanceEndpointResolution(modelId) === size) return { modelId };
+    }
+    return null;
+  }
+  if (!current || current.familyId !== familyId) return withDefaultResolution(resolve());
+
+  // An explicit resolution choice may change the output. All other switches
+  // must retain a known output size, even if its provider route changes.
+  if (Object.hasOwn(changes, "resolution")) return withDefaultResolution(resolve());
+  const sourceResolution = effectiveResolution(currentModelId, nativeResolution);
+  if (sourceResolution === undefined || sourceResolution === "default") {
+    const modelId = resolve();
+    // Extension without an output-size control follows the source video.
+    // The UI can retain its earlier native setting while this field is hidden
+    // and restore that preference when returning to a compatible mode.
+    if (modelId && followsSourceVideoResolution(currentModelId)) {
+      const resolution = matchingValue(getSeedanceCommonOptions(modelForId(modelId)).resolutions, nativeResolution);
+      if (resolution !== undefined) return { modelId, resolution };
+    }
+    return withDefaultResolution(modelId);
+  }
+
+  const outputResolution = normalizeResolution(sourceResolution);
+  const candidates = new Set([resolve(), resolve(outputResolution), resolve("default")]);
+  for (const modelId of candidates) {
+    if (!modelId) continue;
+    const nativeOptions = getSeedanceCommonOptions(modelForId(modelId)).resolutions;
+    const resolution = nativeOptions.find((option) =>
+      String(option).toLowerCase() === outputResolution);
+    if (resolution !== undefined) return { modelId, resolution };
+    if (getSeedanceEndpointResolution(modelId) === outputResolution) return { modelId };
+    if (workflowId === "extend_uploaded_video" && followsSourceVideoResolution(modelId)) return { modelId };
+  }
+  return null;
+}
+
+// These two entries previously exposed a native size input. Preserve the
+// saved output size when restoring them against the corrected API contract.
+export function migrateSeedanceResolutionSelection(modelId, resolution) {
+  if (modelId !== "seedance-2.5-spicy-text-to-video" && modelId !== "seedance-2.5-spicy-image-to-video") return modelId;
+  return resolveSeedanceSelection({
+    familyId: "seedance-2.5",
+    workflowId: modelId.endsWith("image-to-video") ? "animate_image" : null,
+    currentModelId: modelId,
+    changes: { resolution: resolution || "1080p" },
+  })?.modelId || modelId;
+}
+
+// Each output size appears once, regardless of whether the API selects it
+// through a native parameter or a dedicated endpoint. Catalog candidates and
+// the supported size set are bounded; this is one scan of the current mode.
+export function getSeedanceResolutionOptions(
+  familyId,
+  workflowId = null,
+  currentModelId = null,
+  nativeResolution,
+  commonValues = {},
+) {
+  const selected = getSeedanceConfiguration(currentModelId);
+  if (!selected || selected.familyId !== familyId || !selected.workflowIds.includes(workflowId)) {
+    return { value: "", options: [] };
+  }
+  const bySize = new Map();
+  for (const { model, config, options } of selectionCandidates.get(familyId).get(workflowId)) {
+    if (config.profile !== selected.profile || config.speed !== selected.speed) continue;
+    const sizes = options.resolutions.length
+      ? options.resolutions
+      : [getSeedanceEndpointResolution(model.id)];
+    for (const size of sizes) {
+      if (size === undefined) continue;
+      const value = normalizeResolution(size);
+      const selection = {
+        value,
+        label: resolutionLabel(size),
+        modelId: model.id,
+        disabled: false,
+        ...(options.resolutions.length ? { resolution: size } : {}),
+      };
+      const score = [commonAdjustments(model, commonValues).length, model.id === currentModelId ? 0 : 1];
+      const existing = bySize.get(value);
+      if (!existing || compareScores(score, existing.score) < 0) bySize.set(value, { selection, score });
+    }
+  }
+  const value = effectiveResolution(currentModelId, nativeResolution);
+  return {
+    value: value === "default" || value === undefined ? "" : value,
+    options: Object.keys(RESOLUTION_SIZE).flatMap((size) =>
+      bySize.has(size) ? [bySize.get(size).selection] : []),
+  };
+}

--- a/packages/studio/src/videoToolCapabilities.js
+++ b/packages/studio/src/videoToolCapabilities.js
@@ -483,6 +483,8 @@ const CONTINUATION_FAMILIES = Object.freeze({
     sourceModelIds: Object.freeze([
       "seedance-v2.0-t2v",
       "seedance-v2.0-i2v",
+      "seedance-2-t2v",
+      "seedance-2-i2v",
       "seedance-v2.0-extend",
       "seedance-2-extend",
       "seedance-2-vip-extend",
@@ -538,6 +540,18 @@ const CONTINUATION_TARGETS = Object.freeze({
   },
   "grok-imagine-extend": { family: "grok" },
 });
+
+const continuationSourceModelIds = new Map(
+  Object.entries(CONTINUATION_FAMILIES).map(([family, config]) => [
+    family, new Set(config.sourceModelIds),
+  ]),
+);
+
+export function isContinuationSourceModel(modelOrId, sourceModelId) {
+  const modelId = typeof modelOrId === "string" ? modelOrId : modelOrId?.id;
+  const family = CONTINUATION_TARGETS[modelId]?.family;
+  return continuationSourceModelIds.get(family)?.has(sourceModelId) || false;
+}
 
 const MIN_CLIENT_TIMESTAMP = Date.UTC(2000, 0, 1);
 const MAX_CLIENT_TIMESTAMP = Date.UTC(2101, 0, 1);
@@ -731,11 +745,10 @@ function resolveContinuationRequestId(entry) {
 export function getCompatibleContinuationSources(modelOrId, history = []) {
   const config = getContinuationConfig(modelOrId);
   if (!config) return [];
-  const compatibleModelIds = new Set(config.sourceModelIds);
   const sources = [];
 
   for (const entry of history) {
-    if (!entry?.url || !compatibleModelIds.has(entry.model)) continue;
+    if (!entry?.url || !isContinuationSourceModel(modelOrId, entry.model)) continue;
     const requestId = resolveContinuationRequestId(entry);
     if (!requestId) continue;
     if (config.requiredSourceResolution) {

--- a/packages/studio/src/videoWorkflows.js
+++ b/packages/studio/src/videoWorkflows.js
@@ -3,6 +3,11 @@ import {
   videoModelCatalog,
   videoModelPickerEntryByVariantId,
 } from "./modelFamilies.js";
+import {
+  SEEDANCE_WORKFLOW_VARIANTS,
+  getSeedanceConfiguration,
+  resolveSeedanceVariant,
+} from "./seedanceModels.js";
 
 export const VIDEO_WORKFLOW_IDS = Object.freeze([
   "animate_image",
@@ -76,45 +81,6 @@ export const VIDEO_WORKFLOW_VARIANTS = Object.freeze({
     references: [
       "minimax-h3-open-reference-to-video",
       "minimax-h3-reference-to-video",
-    ],
-  },
-  "seedance-2": {
-    animate_image: [
-      "seedance-2-i2v",
-      "seedance-2-i2v-480p",
-      "seedance-2-image-to-video",
-      "seedance-2-image-to-video-fast",
-      "seedance-2-vip-image-to-video",
-      "seedance-2-vip-image-to-video-fast",
-      "seedance-2-vip-image-to-video-1080p",
-      "seedance-2-vip-image-to-video-fast-1080p",
-      "seedance-2-vip-image-to-video-4k",
-      "seedance-2-mini-image-to-video",
-      "seedance-2-spicy-image-to-video",
-      "seedance-2-spicy-image-to-video-fast",
-      "seedance-2-mini-spicy-image-to-video",
-    ],
-    keyframes: [
-      "seedance-2-new-first-last",
-      "seedance-2-first-last-frame",
-      "seedance-2-first-last-frame-fast",
-      "seedance-2-vip-first-last-frame",
-      "seedance-2-vip-first-last-frame-fast",
-      "seedance-2-vip-first-last-frame-1080p",
-      "seedance-2-vip-first-last-frame-4k",
-    ],
-    references: [
-      "seedance-2-new-omni",
-      "seedance-2-omni-reference",
-      "seedance-2-omni-reference-480p",
-      "seedance-2-omni-reference-no-video",
-      "seedance-2-omni-reference-no-video-fast",
-      "seedance-2-vip-omni-reference",
-      "seedance-2-vip-omni-reference-fast",
-      "seedance-2-vip-omni-reference-1080p",
-      "seedance-2-vip-omni-reference-fast-1080p",
-      "seedance-2-vip-omni-reference-4k",
-      "seedance-2-mini-omni-reference",
     ],
   },
   "gemini-omni": {
@@ -201,14 +167,6 @@ export const VIDEO_WORKFLOW_VARIANTS = Object.freeze({
     animate_image: ["ltx-2.3-image-to-video"],
     extend_uploaded_video: ["ltx-2.3-video-extend"],
   },
-  "seedance-1.5": {
-    animate_image: ["seedance-v1.5-pro-i2v-fast", "seedance-v1.5-pro-i2v"],
-    keyframes: ["seedance-v1.5-pro-i2v-fast", "seedance-v1.5-pro-i2v"],
-    extend_uploaded_video: [
-      "seedance-v1.5-pro-video-extend-fast",
-      "seedance-v1.5-pro-video-extend",
-    ],
-  },
   "wan-2.2": {
     animate_image: ["wan2.2-spicy-image-to-video", "wan2.2-image-to-video"],
     keyframes: ["wan2.2-image-to-video"],
@@ -218,11 +176,6 @@ export const VIDEO_WORKFLOW_VARIANTS = Object.freeze({
   "wan-2.1": {
     animate_image: ["wan2.1-image-to-video"],
     references: ["wan2.1-reference-video"],
-  },
-  "seedance-lite": {
-    animate_image: ["seedance-lite-i2v"],
-    keyframes: ["seedance-lite-i2v"],
-    references: ["seedance-lite-reference-video"],
   },
   "minimax-hailuo-02": {
     animate_image: ["minimax-hailuo-02-pro-i2v", "minimax-hailuo-02-standard-i2v"],
@@ -236,6 +189,7 @@ export const VIDEO_WORKFLOW_VARIANTS = Object.freeze({
     ],
     keyframes: ["kling-v2.1-pro-i2v"],
   },
+  ...SEEDANCE_WORKFLOW_VARIANTS,
 });
 
 const TECHNICAL_EXCLUDED_VARIANTS = Object.freeze({
@@ -461,6 +415,38 @@ function sameFamilyVariantId(familyId, variantId) {
     : null;
 }
 
+function resolveSeedanceWorkflowVariant(
+  familyId,
+  workflowId,
+  group,
+  currentVariantId,
+  preferredVariantId,
+) {
+  const current = getSeedanceConfiguration(currentVariantId);
+  const preferred = getSeedanceConfiguration(preferredVariantId);
+  const hasCurrent = current?.familyId === familyId;
+  const hasPreferred = preferred?.familyId === familyId;
+  // Remembering a workflow must not silently change a selected service,
+  // speed, or endpoint resolution when the user changes its source mode.
+  const canRestorePreferred = hasPreferred && (!hasCurrent || (
+    current.profile === preferred.profile &&
+    current.speed === preferred.speed &&
+    current.resolution === preferred.resolution
+  ));
+  if (canRestorePreferred) {
+    const remembered = variantForId(group, preferredVariantId);
+    if (remembered) return remembered;
+  }
+  const variantId = resolveSeedanceVariant({
+    familyId,
+    workflowId,
+    currentModelId: hasCurrent
+      ? currentVariantId
+      : hasPreferred ? preferredVariantId : null,
+  });
+  return variantForId(group, variantId);
+}
+
 export function resolveVideoWorkflowVariant(
   familyId,
   workflowId,
@@ -469,6 +455,11 @@ export function resolveVideoWorkflowVariant(
 ) {
   const group = getVideoWorkflowGroup(familyId, workflowId);
   if (!group) return null;
+  if (SEEDANCE_WORKFLOW_VARIANTS[familyId]) {
+    return resolveSeedanceWorkflowVariant(
+      familyId, workflowId, group, currentVariantId, preferredVariantId,
+    );
+  }
   return resolveVariantFromGroup(
     group,
     sameFamilyVariantId(familyId, currentVariantId),
@@ -483,6 +474,11 @@ export function resolveVideoBaseVariant(
 ) {
   const group = getVideoWorkflowGroup(familyId, null);
   if (!group) return null;
+  if (SEEDANCE_WORKFLOW_VARIANTS[familyId]) {
+    return resolveSeedanceWorkflowVariant(
+      familyId, null, group, currentVariantId, preferredVariantId,
+    );
+  }
   return resolveVariantFromGroup(
     group,
     sameFamilyVariantId(familyId, currentVariantId),
@@ -493,9 +489,10 @@ export function resolveVideoBaseVariant(
 export function inferVideoWorkflowId(
   familyId,
   variantId,
-  { hasEndFrame = false } = {},
+  { hasEndFrame = false, preferredWorkflowId = null } = {},
 ) {
   const ids = getVideoWorkflowFamily(familyId)?.workflowIdsByVariantId.get(variantId) || [];
+  if (ids.includes(preferredWorkflowId)) return preferredWorkflowId;
   if (hasEndFrame && ids.includes("keyframes")) return "keyframes";
   if (ids.includes("animate_image")) return "animate_image";
   return ids[0] || null;
@@ -573,6 +570,10 @@ export function getVideoWorkflowMediaConfig(model, workflowId) {
   if (workflowId === "edit_video" || workflowId === "extend_uploaded_video") {
     return {
       ...config,
+      imageLimit: workflowId === "extend_uploaded_video" &&
+        getSeedanceConfiguration(model?.id)?.familyId === "seedance-2.5"
+        ? Math.min(config.imageLimit, 1)
+        : config.imageLimit,
       videoLimit: Math.min(config.videoLimit, 1),
       separateEndImage: false,
     };
@@ -671,7 +672,8 @@ export function getVideoWorkflowMediaSlots(model, workflowId) {
   }
   if (workflowId === "keyframes") {
     if (!imageField) return [];
-    const sharedArrayField = capabilities.image.isArray && !lastImageField;
+    const sharedArrayField = capabilities.image.isArray &&
+      (!lastImageField || lastImageField === imageField);
     return [
       createMediaSlot(
         "startFrame",
@@ -746,6 +748,14 @@ export function getVideoWorkflowMediaSlots(model, workflowId) {
         Math.max(capabilities.image.maxItems, 1),
         {
           isArray: capabilities.image.isArray,
+          ...(SEEDANCE_WORKFLOW_VARIANTS[familyId] &&
+            model.inputs?.[capabilities.image.field]?.minItems > 0
+            ? {
+              required: true,
+              minItems: model.inputs[capabilities.image.field].minItems,
+              requiredMessage: "Please add a reference image.",
+            }
+            : {}),
           ...(familyId === "minimax-h3"
             ? MINIMAX_H3_REFERENCE_CONSTRAINT
             : {}),
@@ -822,6 +832,14 @@ export function getVideoWorkflowMediaSlots(model, workflowId) {
         "Video to extend",
         1,
         { isArray: capabilities.video.isArray },
+      ),
+      familyId === "seedance-2.5" && lastImageField && createMediaSlot(
+        "endFrame",
+        "image",
+        lastImageField,
+        "End",
+        "Optional target frame for the continuation",
+        1,
       ),
       audioField && createMediaSlot(
         "referenceAudios",
@@ -977,6 +995,11 @@ export function validateVideoWorkflowMedia(workflowId, media = {}, model = null)
   )) {
     if (mediaCount(activeMedia, slotId) === 0) {
       return { valid: false, message };
+    }
+  }
+  for (const slot of slots) {
+    if (slot.minItems && mediaCount(activeMedia, slot.id) < slot.minItems) {
+      return { valid: false, message: slot.requiredMessage };
     }
   }
 


### PR DESCRIPTION
## Changes

- Group Seedance variants by version, with clear video modes and settings in the composer.
- Show supported parameters and resolutions, and preserve compatible settings and media when switching modes.

Validation: Studio build and desktop/mobile browser checks.